### PR TITLE
Feature/rst 1023 dev

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,7 @@
+AWS_ACCESS_KEY_ID=accessKey1
+AWS_SECRET_ACCESS_KEY=verySecretKey1
+AWS_REGION=us-east-1
+S3_UPLOAD_BUCKET=etapibucket_test
+S3_DIRECT_UPLOAD_BUCKET=etapidirectbuckettest
+AWS_ENDPOINT=http://localhost:8000
+AWS_S3_FORCE_PATH_STYLE=true

--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,7 @@
 AWS_ACCESS_KEY_ID=accessKey1
 AWS_SECRET_ACCESS_KEY=verySecretKey1
 AWS_REGION=us-east-1
-S3_UPLOAD_BUCKET=etapibucket_test
+S3_UPLOAD_BUCKET=etapibuckettest
 S3_DIRECT_UPLOAD_BUCKET=etapidirectbuckettest
-AWS_ENDPOINT=http://localhost:8000
+AWS_ENDPOINT=http://localhost:9000
 AWS_S3_FORCE_PATH_STYLE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   global:
     - ENABLE_COVERAGE=true
     - DB_USERNAME=postgres
+    - DB_PORT=5433
+    - S3_PORT=9000
     - CC_TEST_REPORTER=935a4195bd35a993666acc398a01a53daf4e7f11635e90a51c8f30b44cbe1ec9
 before_install:
   - sudo rm /usr/local/bin/docker-compose
@@ -23,10 +25,9 @@ before_install:
   - "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter && chmod +x ./cc-test-reporter"
   - sudo apt-get install pdftk
 before_script:
-  - S3_PORT=9000 DB_PORT=5433 ./bin/dev/docker-support-services up -d
+  - ./bin/dev/docker-support-services up -d
   - ./bin/wait-for-it.sh localhost:9000
   - ./bin/wait-for-it.sh localhost:5433
-  - export DB_PORT=5433
   - bundle install && bundle exec rails db:create db:migrate RAILS_ENV=test
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,25 @@ cache:
 services:
   - postgresql
 addons:
-  postgresql: '9.5'
+  apt:
+    packages:
+      - docker-ce
 env:
   global:
     - ENABLE_COVERAGE=true
     - DB_USERNAME=postgres
     - CC_TEST_REPORTER=935a4195bd35a993666acc398a01a53daf4e7f11635e90a51c8f30b44cbe1ec9
 before_install:
-  - wget https://dl.minio.io/server/minio/release/linux-amd64/minio
-  - chmod +x minio
-  - ./minio server /data
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.21.0/docker-compose-Linux-x86_64 > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
   - "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter && chmod +x ./cc-test-reporter"
   - sudo apt-get install pdftk
 before_script:
+  - S3_PORT=9000 DB_PORT=5432 ./bin/dev/docker-support-services up -d
+  - ./bin/wait-for-it.sh localhost:9000
+  - ./bin/wait-for-it.sh localhost:5432
   - bundle install && bundle exec rails db:create db:migrate RAILS_ENV=test
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,23 @@ cache:
 services:
   - postgresql
 addons:
-  postgresql: '9.5'
+  apt:
+    packages:
+      - docker-ce
 env:
   global:
     - ENABLE_COVERAGE=true
     - DB_USERNAME=postgres
     - CC_TEST_REPORTER=935a4195bd35a993666acc398a01a53daf4e7f11635e90a51c8f30b44cbe1ec9
 before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.21.0/docker-compose-Linux-x86_64 > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
   - "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter && chmod +x ./cc-test-reporter"
   - sudo apt-get install pdftk
 before_script:
+  - ./bin/dev/docker-support-services up -d
   - bundle install && bundle exec rails db:create db:migrate RAILS_ENV=test
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ cache:
   directories:
       - tmp/parallel_runtime_log
 services:
-  - docker
+  - postgresql
 addons:
   apt:
     packages:
       - docker-ce
+      - postgresql: '9.5'
 env:
   global:
     - ENABLE_COVERAGE=true
@@ -23,9 +24,8 @@ before_install:
   - "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter && chmod +x ./cc-test-reporter"
   - sudo apt-get install pdftk
 before_script:
-  - S3_PORT=9000 DB_PORT=5432 ./bin/dev/docker-support-services up -d
+  - S3_PORT=9000 ./bin/dev/docker-support-services up -d
   - ./bin/wait-for-it.sh localhost:9000
-  - ./bin/wait-for-it.sh localhost:5432
   - bundle install && bundle exec rails db:create db:migrate RAILS_ENV=test
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
       - tmp/parallel_runtime_log
 services:
-  - postgresql
+  - docker
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
   apt:
     packages:
       - docker-ce
-      - postgresql: '9.5'
 env:
   global:
     - ENABLE_COVERAGE=true
@@ -24,8 +23,10 @@ before_install:
   - "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter && chmod +x ./cc-test-reporter"
   - sudo apt-get install pdftk
 before_script:
-  - S3_PORT=9000 ./bin/dev/docker-support-services up -d
+  - S3_PORT=9000 DB_PORT=5433 ./bin/dev/docker-support-services up -d
   - ./bin/wait-for-it.sh localhost:9000
+  - ./bin/wait-for-it.sh localhost:5433
+  - export DB_PORT=5433
   - bundle install && bundle exec rails db:create db:migrate RAILS_ENV=test
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,19 @@ cache:
 services:
   - postgresql
 addons:
-  apt:
-    packages:
-      - docker-ce
+  postgresql: '9.5'
 env:
   global:
     - ENABLE_COVERAGE=true
     - DB_USERNAME=postgres
     - CC_TEST_REPORTER=935a4195bd35a993666acc398a01a53daf4e7f11635e90a51c8f30b44cbe1ec9
 before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/1.21.0/docker-compose-Linux-x86_64 > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
+  - wget https://dl.minio.io/server/minio/release/linux-amd64/minio
+  - chmod +x minio
+  - ./minio server /data
   - "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter && chmod +x ./cc-test-reporter"
   - sudo apt-get install pdftk
 before_script:
-  - ./bin/dev/docker-support-services up -d
   - bundle install && bundle exec rails db:create db:migrate RAILS_ENV=test
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 3.7'
   gem 'simplecov', '~> 0.16.1'
+  gem 'dotenv-rails', '~> 2.4'
 end
 
 group :development do
@@ -58,15 +59,16 @@ end
 group :test do
   gem 'database_cleaner', '~> 1.6.2'
   gem 'factory_bot', '~> 4.8'
-  gem 'aws-sdk-s3', '~> 1.8', '>= 1.8.2'
+  gem 'aws-sdk-s3', '~> 1.13'
   gem 'rspec-eventually', '~> 0.2.2'
   gem 'faker', '~> 1.8', '>= 1.8.7'
   gem 'webmock', '~> 3.4', '>= 3.4.1'
 end
 
 group :production do
-  gem 'aws-sdk-s3', '~> 1.8', '>= 1.8.2'
+  gem 'aws-sdk-s3', '~> 1.13'
 end
+
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'rubyzip', '~> 1.2', '>= 1.2.1'
 # Pdf forms to test pdf content and also to produce them
 gem 'pdf-forms', '~> 1.1', '>= 1.1.1'
 
+# AWS SDK gem
+gem 'aws-sdk-s3', '~> 1.13'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -59,16 +62,10 @@ end
 group :test do
   gem 'database_cleaner', '~> 1.6.2'
   gem 'factory_bot', '~> 4.8'
-  gem 'aws-sdk-s3', '~> 1.13'
   gem 'rspec-eventually', '~> 0.2.2'
   gem 'faker', '~> 1.8', '>= 1.8.7'
   gem 'webmock', '~> 3.4', '>= 3.4.1'
 end
-
-group :production do
-  gem 'aws-sdk-s3', '~> 1.13'
-end
-
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,16 +77,18 @@ GEM
       nokogiri
     arel (9.0.0)
     ast (2.4.0)
-    aws-partitions (1.76.0)
-    aws-sdk-core (3.18.1)
+    aws-eventstream (1.0.0)
+    aws-partitions (1.87.0)
+    aws-sdk-core (3.21.2)
+      aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
     aws-sdk-kms (1.5.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.8.2)
-      aws-sdk-core (~> 3)
+    aws-sdk-s3 (1.13.0)
+      aws-sdk-core (~> 3, >= 3.21.2)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.2)
@@ -101,6 +103,10 @@ GEM
     database_cleaner (1.6.2)
     diff-lcs (1.3)
     docile (1.3.0)
+    dotenv (2.4.0)
+    dotenv-rails (2.4.0)
+      dotenv (= 2.4.0)
+      railties (>= 3.2, < 6.0)
     erubi (1.7.1)
     et-orbi (1.1.0)
       tzinfo
@@ -122,7 +128,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
-    jmespath (1.3.1)
+    jmespath (1.4.0)
     json (2.1.0)
     kgio (2.11.2)
     listen (3.1.5)
@@ -291,10 +297,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk-s3 (~> 1.8, >= 1.8.2)
+  aws-sdk-s3 (~> 1.13)
   byebug
   database_cleaner (~> 1.6.2)
   et_acas_api!
+  dotenv-rails (~> 2.4)
   et_atos_file_transfer!
   et_fake_acas_server!
   factory_bot (~> 4.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,9 +77,9 @@ GEM
       nokogiri
     arel (9.0.0)
     ast (2.4.0)
-    aws-eventstream (1.0.0)
-    aws-partitions (1.87.0)
-    aws-sdk-core (3.21.2)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.93.0)
+    aws-sdk-core (3.21.3)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -87,7 +87,7 @@ GEM
     aws-sdk-kms (1.5.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.13.0)
+    aws-sdk-s3 (1.14.0)
       aws-sdk-core (~> 3, >= 3.21.2)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -103,9 +103,9 @@ GEM
     database_cleaner (1.6.2)
     diff-lcs (1.3)
     docile (1.3.0)
-    dotenv (2.4.0)
-    dotenv-rails (2.4.0)
-      dotenv (= 2.4.0)
+    dotenv (2.5.0)
+    dotenv-rails (2.5.0)
+      dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
     erubi (1.7.1)
     et-orbi (1.1.0)
@@ -300,8 +300,8 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.13)
   byebug
   database_cleaner (~> 1.6.2)
-  et_acas_api!
   dotenv-rails (~> 2.4)
+  et_acas_api!
   et_atos_file_transfer!
   et_fake_acas_server!
   factory_bot (~> 4.8)

--- a/README.md
+++ b/README.md
@@ -273,7 +273,13 @@ EXPORT_CLAIMS_EVERY=5
 
 ```
 
+
 will set it to every 5 minutes
+
+## S3_DIRECT_UPLOAD_BUCKET
+
+In contrast to S3_UPLOAD_BUCKET which is for storing active storage objects, this environment variable points to
+a bucket where mthe direct upload feature can be used in a front end application using the API.
 
 # Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Both server, client and nescessary headers for development
 
 Used for background jobs - not entirely nescessary depending on what you are working on
 
+### minio
+
+We use amazon S3 wired up to active storage, which you would normally use a test adapter for, however we also have
+some code that copies from one S3 bucket to another which cannot use active storage - so instead, we just use an S3
+server (I chose minio as it has been the most reliable and most feature rich).  See its github page for more
+details (https://github.com/minio/minio) - you can install it on OSX and linux - or you can use docker (note that it
+is integrated into ./bin/dev/docker-support-services
+
 ## Developing And Testing Using Docker
 
 ### Initial Setup (Run once)

--- a/app/commands/create_signed_s3_form_data_command.rb
+++ b/app/commands/create_signed_s3_form_data_command.rb
@@ -1,0 +1,5 @@
+class CreateSignedS3FormDataCommand < BaseCommand
+  def apply(root_object)
+    root_object.merge!(input_data)
+  end
+end

--- a/app/controllers/api/v2/s3/signed_urls_controller.rb
+++ b/app/controllers/api/v2/s3/signed_urls_controller.rb
@@ -4,9 +4,10 @@ module Api
       class SignedUrlsController < ::ApplicationController
         def create
           root_object = {}
-          result = CommandService.dispatch root_object: root_object, **(create_params.to_h.symbolize_keys)
+          result = CommandService.dispatch root_object: root_object, **create_params.to_h.symbolize_keys
           EventService.publish('SignedS3FormDataCreated', root_object)
-          render locals: { result: result, data: root_object }, status: (result.valid? ? :accepted : :unprocessable_entity)
+          render locals: { result: result, data: root_object },
+                 status: (result.valid? ? :accepted : :unprocessable_entity)
         end
 
         private

--- a/app/controllers/api/v2/s3/signed_urls_controller.rb
+++ b/app/controllers/api/v2/s3/signed_urls_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V2
+    module S3
+      class SignedUrlsController < ::ApplicationController
+        def create
+          root_object = {}
+          result = CommandService.dispatch root_object: root_object, **(create_params.to_h.symbolize_keys)
+          EventService.publish('SignedS3FormDataCreated', root_object)
+          render locals: { result: result, data: root_object }, status: (result.valid? ? :accepted : :unprocessable_entity)
+        end
+
+        private
+
+        def create_params
+          params.permit(:uuid, :command, :async, data: {})
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/s3/signed_urls_controller.rb
+++ b/app/controllers/api/v2/s3/signed_urls_controller.rb
@@ -4,7 +4,7 @@ module Api
       class SignedUrlsController < ::ApplicationController
         def create
           root_object = {}
-          result = CommandService.dispatch root_object: root_object, **create_params.to_h.symbolize_keys
+          result = CommandService.dispatch root_object: root_object, data: {}, **create_params.to_h.symbolize_keys
           EventService.publish('SignedS3FormDataCreated', root_object)
           render locals: { result: result, data: root_object },
                  status: (result.valid? ? :accepted : :unprocessable_entity)
@@ -15,6 +15,7 @@ module Api
         def create_params
           params.permit(:uuid, :command, :async, data: {})
         end
+
       end
     end
   end

--- a/app/event_handlers/signed_s3_form_data_created_handler.rb
+++ b/app/event_handlers/signed_s3_form_data_created_handler.rb
@@ -1,0 +1,61 @@
+class SignedS3FormDataCreatedHandler
+  def handle(root)
+    # @TODO - Sort this lot out
+
+    bucket = find_or_create_bucket
+    post = bucket.presigned_post(key: root['key'])
+    root[:output_values] = {}
+    root[:output_values][:fields] = post.fields
+    root[:output_values][:url] = post.url
+  end
+
+  private
+
+  def client
+    @client ||= Aws::S3::Client.new client_config
+  end
+
+  def find_or_create_bucket
+    Aws::S3::Bucket.new(client: client, name: bucket_name).tap do |bucket|
+      bucket.create unless bucket.exists?
+    end
+  end
+
+  def client_config
+    @config ||= begin
+      config = {
+        access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID', ''),
+        secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY', ''),
+        region: ENV.fetch('AWS_REGION', 'eu-west-1')
+      }
+      config[:endpoint] = ENV.fetch('AWS_ENDPOINT') if ENV.key?('AWS_ENDPOINT')
+      config[:force_path_style] = true if ENV.fetch('AWS_S3_FORCE_PATH_STYLE', 'false') == 'true'
+      config
+    end
+  end
+
+  def bucket_name
+    ENV.fetch('S3_DIRECT_UPLOAD_BUCKET')
+  end
+
+  def key
+    @key ||= "/direct_uploads/#{SecureRandom.uuid}"
+  end
+
+  def acl
+    'public-read'
+  end
+
+  def algorithm
+    'AWS4-HMAC-SHA256'
+  end
+
+  def success_action_redirect
+    "http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html"
+  end
+
+  def endpoint
+    ENV.fetch('AWS_ENDPOINT')
+  end
+
+end

--- a/app/event_handlers/signed_s3_form_data_created_handler.rb
+++ b/app/event_handlers/signed_s3_form_data_created_handler.rb
@@ -1,9 +1,6 @@
 class SignedS3FormDataCreatedHandler
   def handle(root)
-    # @TODO - Sort this lot out
-
-    bucket = find_or_create_bucket
-    post = bucket.presigned_post(key: root['key'])
+    post = find_or_create_bucket.presigned_post(key: key)
     root[:output_values] = {}
     root[:output_values][:fields] = post.fields
     root[:output_values][:url] = post.url
@@ -12,7 +9,7 @@ class SignedS3FormDataCreatedHandler
   private
 
   def client
-    @client ||= Aws::S3::Client.new client_config
+    @client ||= ActiveStorage::Blob.service.client.client
   end
 
   def find_or_create_bucket
@@ -21,41 +18,11 @@ class SignedS3FormDataCreatedHandler
     end
   end
 
-  def client_config
-    @config ||= begin
-      config = {
-        access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID', ''),
-        secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY', ''),
-        region: ENV.fetch('AWS_REGION', 'eu-west-1')
-      }
-      config[:endpoint] = ENV.fetch('AWS_ENDPOINT') if ENV.key?('AWS_ENDPOINT')
-      config[:force_path_style] = true if ENV.fetch('AWS_S3_FORCE_PATH_STYLE', 'false') == 'true'
-      config
-    end
-  end
-
   def bucket_name
-    ENV.fetch('S3_DIRECT_UPLOAD_BUCKET')
+    @bucket_name ||= Rails.configuration.s3_direct_upload_bucket
   end
 
   def key
-    @key ||= "/direct_uploads/#{SecureRandom.uuid}"
+    @key ||= "direct_uploads/#{SecureRandom.uuid}"
   end
-
-  def acl
-    'public-read'
-  end
-
-  def algorithm
-    'AWS4-HMAC-SHA256'
-  end
-
-  def success_action_redirect
-    "http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html"
-  end
-
-  def endpoint
-    ENV.fetch('AWS_ENDPOINT')
-  end
-
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -5,12 +5,7 @@ class Response < ApplicationRecord
   has_many :uploaded_files, through: :response_uploaded_files
 
   def additional_information_key=(value)
-    existing = ai_file
-    if existing
-      update_or_remove_ai_file(value, existing)
-    else
-      create_ai_file(value)
-    end
+    DirectUploadIntoCollectionService.new(collection: uploaded_files, filename: 'additional_information.rtf').import(value)
   end
 
   def has_additional_information_rtf_file?
@@ -19,43 +14,7 @@ class Response < ApplicationRecord
 
   private
 
-  def update_or_remove_ai_file(value, existing)
-    if value.nil?
-      remove_ai_file(existing)
-    else
-      update_ai_file(value, into: existing)
-    end
-  end
-
   def ai_file
     uploaded_files.detect { |file| file.filename == 'additional_information.rtf' }
-  end
-
-  def remove_ai_file(existing)
-    uploaded_files.delete(existing)
-  end
-
-  def create_ai_file(value)
-    return if value.nil?
-    s3_client = ActiveStorage::Blob.service.client.client
-    source_object = s3_client.get_object(bucket: direct_upload_bucket, key: value)
-    blob = ActiveStorage::Blob.create!(filename: 'additional_information.rtf',
-                                       byte_size: source_object.content_length,
-                                       checksum: 'doesntseemtomatter',
-                                       content_type: 'application/rtf',
-                                       metadata: {})
-    object = blob.service.bucket.object(blob.key)
-    object.copy_from(bucket: direct_upload_bucket, key: value)
-    uploaded_files.build(filename: 'additional_information.rtf', file: blob)
-  end
-
-  def update_ai_file(value, into:)
-    blob = into.file.blob
-    object = blob.service.bucket.object(blob.key)
-    object.copy_from(bucket: direct_upload_bucket, key: value)
-  end
-
-  def direct_upload_bucket
-    @direct_upload_bucket ||= Rails.configuration.s3_direct_upload_bucket
   end
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -4,4 +4,54 @@ class Response < ApplicationRecord
   has_many :response_uploaded_files, dependent: :destroy
   has_many :uploaded_files, through: :response_uploaded_files
 
+  def additional_information_key=(value)
+    existing = ai_file
+    if existing
+      update_or_remove_ai_file(value, existing)
+    else
+      create_ai_file(value)
+    end
+  end
+
+  private
+
+  def update_or_remove_ai_file(value, existing)
+    if value.nil?
+      remove_ai_file(existing)
+    else
+      update_ai_file(value, into: existing)
+    end
+  end
+
+  def ai_file
+    uploaded_files.detect { |file| file.filename == 'additional_information.rtf' }
+  end
+
+  def remove_ai_file(existing)
+    uploaded_files.delete(existing)
+  end
+
+  def create_ai_file(value)
+    return if value.nil?
+    s3_client = ActiveStorage::Blob.service.client.client
+    source_object = s3_client.get_object(bucket: direct_upload_bucket, key: value)
+    blob = ActiveStorage::Blob.create!(filename: 'additional_information.rtf',
+                                       byte_size: source_object.content_length,
+                                       checksum: 'doesntseemtomatter',
+                                       content_type: 'application/rtf',
+                                       metadata: {})
+    object = blob.service.bucket.object(blob.key)
+    object.copy_from(bucket: direct_upload_bucket, key: value)
+    uploaded_files.build(filename: 'additional_information.rtf', file: blob)
+  end
+
+  def update_ai_file(value, into:)
+    blob = into.file.blob
+    object = blob.service.bucket.object(blob.key)
+    object.copy_from(bucket: direct_upload_bucket, key: value)
+  end
+
+  def direct_upload_bucket
+    @direct_upload_bucket ||= Rails.configuration.s3_direct_upload_bucket
+  end
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -13,6 +13,10 @@ class Response < ApplicationRecord
     end
   end
 
+  def has_additional_information_rtf_file?
+    ai_file.present?
+  end
+
   private
 
   def update_or_remove_ai_file(value, existing)

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -5,10 +5,11 @@ class Response < ApplicationRecord
   has_many :uploaded_files, through: :response_uploaded_files
 
   def additional_information_key=(value)
-    DirectUploadIntoCollectionService.new(collection: uploaded_files, filename: 'additional_information.rtf').import(value)
+    service = DirectUploadIntoCollectionService.new(collection: uploaded_files, filename: 'additional_information.rtf')
+    service.import(value)
   end
 
-  def has_additional_information_rtf_file?
+  def additional_information_rtf_file?
     ai_file.present?
   end
 

--- a/app/services/claim_file_builder/build_response_pdf_file.rb
+++ b/app/services/claim_file_builder/build_response_pdf_file.rb
@@ -50,7 +50,7 @@ module ClaimFileBuilder
 
     def apply_header_pdf_fields(result)
       result['case number'] = response.case_number
-      result['RTF'] = response.has_additional_information_rtf_file? ? 'Additional RTF' : ''
+      result['RTF'] = response.additional_information_rtf_file? ? 'Additional RTF' : ''
     end
 
     def apply_claimant_pdf_fields(result)

--- a/app/services/claim_file_builder/build_response_pdf_file.rb
+++ b/app/services/claim_file_builder/build_response_pdf_file.rb
@@ -50,6 +50,7 @@ module ClaimFileBuilder
 
     def apply_header_pdf_fields(result)
       result['case number'] = response.case_number
+      result['RTF'] = response.has_additional_information_rtf_file? ? 'Additional RTF' : ''
     end
 
     def apply_claimant_pdf_fields(result)

--- a/app/services/claim_file_builder/build_response_rtf_file.rb
+++ b/app/services/claim_file_builder/build_response_rtf_file.rb
@@ -1,0 +1,18 @@
+module ClaimFileBuilder
+  module BuildResponseRtfFile
+    def self.call(response)
+      filename = 'et3_atos_export.rtf'
+      original = input_file(response: response)
+      return if original.nil?
+      response.uploaded_files.build filename: filename,
+                                    file: original.file.blob,
+                                    checksum: original.checksum
+    end
+
+    def self.input_file(response:)
+      response.uploaded_files.detect { |u| u.filename == 'additional_information.rtf' }
+    end
+
+    private_class_method :input_file
+  end
+end

--- a/app/services/direct_upload_into_collection_service.rb
+++ b/app/services/direct_upload_into_collection_service.rb
@@ -56,7 +56,6 @@ class DirectUploadIntoCollectionService
     object.copy_from(bucket: direct_upload_bucket, key: value)
   end
 
-
   def direct_upload_bucket
     @direct_upload_bucket ||= Rails.configuration.s3_direct_upload_bucket
   end
@@ -64,5 +63,4 @@ class DirectUploadIntoCollectionService
   def s3_client
     @s3_client ||= ActiveStorage::Blob.service.client.client
   end
-
 end

--- a/app/services/direct_upload_into_collection_service.rb
+++ b/app/services/direct_upload_into_collection_service.rb
@@ -1,0 +1,68 @@
+class DirectUploadIntoCollectionService
+  def initialize(collection:, filename:)
+    self.collection = collection
+    self.filename = filename
+  end
+
+  def import(value)
+    existing = find_file
+    update_or_delete(value, existing) if existing
+    create_file(value) unless existing || value.nil?
+  end
+
+  private
+
+  def update_or_delete(value, existing = find_file)
+    if value.present?
+      update_file(value, into: existing)
+    else
+      delete_file(existing)
+    end
+  end
+
+  attr_accessor :collection, :filename
+
+  def find_file
+    collection.detect { |file| file.filename == filename }
+  end
+
+  def create_file(value)
+    blob = ActiveStorage::Blob.create!(blob_attributes_for(value))
+    import_into_blob(blob, value)
+    collection.build(filename: filename, file: blob)
+  end
+
+  def update_file(value, into:)
+    into.file.update(blob_attributes_for(value))
+    blob = into.file.blob
+    import_into_blob(blob, value)
+  end
+
+  def delete_file(existing = find_file)
+    collection.delete(existing)
+  end
+
+  def blob_attributes_for(value)
+    source_object = s3_client.get_object(bucket: direct_upload_bucket, key: value)
+    { filename: filename,
+      byte_size: source_object.content_length,
+      checksum: 'doesntseemtomatter',
+      content_type: 'application/rtf',
+      metadata: {} }
+  end
+
+  def import_into_blob(blob, value)
+    object = blob.service.bucket.object(blob.key)
+    object.copy_from(bucket: direct_upload_bucket, key: value)
+  end
+
+
+  def direct_upload_bucket
+    @direct_upload_bucket ||= Rails.configuration.s3_direct_upload_bucket
+  end
+
+  def s3_client
+    @s3_client ||= ActiveStorage::Blob.service.client.client
+  end
+
+end

--- a/app/services/export_service_exporters/response_exporter.rb
+++ b/app/services/export_service_exporters/response_exporter.rb
@@ -28,11 +28,20 @@ module ExportServiceExporters
     def export_files(response, to:)
       export_file(response: response, to: to, ext: :txt, type: :txt)
       export_file(response: response, to: to, ext: :pdf, type: :pdf)
+      export_file_as_attachment(response: response, to: to, ext: :rtf, type: :rtf, optional: true)
     end
 
     def export_file(response:, to:, ext:, type:)
       stored_file = response_export_service.new(response).send(:"export_#{type}")
       fn = "#{response.reference}_ET3_.#{ext}"
+      stored_file.download_blob_to File.join(to, fn)
+    end
+
+    def export_file_as_attachment(response:, to:, ext:, type:, optional: false)
+      stored_file = response_export_service.new(response).send(:"export_#{type}")
+      return if optional && stored_file.nil?
+      company_name_underscored = response.respondent.name.split(/\W/).join('_')
+      fn = "#{response.reference}_ET3_Attachment_#{company_name_underscored}.#{ext}"
       stored_file.download_blob_to File.join(to, fn)
     end
 

--- a/app/services/response_file_builder_service.rb
+++ b/app/services/response_file_builder_service.rb
@@ -3,13 +3,18 @@
 # This service takes a built response and produces all files required to be attached
 #
 class ResponseFileBuilderService
-  def initialize(response, response_text_file_builder: ClaimFileBuilder::BuildResponseTextFile, response_pdf_file_builder: ClaimFileBuilder::BuildResponsePdfFile)
+  def initialize(response,
+    response_text_file_builder: ClaimFileBuilder::BuildResponseTextFile,
+    response_pdf_file_builder: ClaimFileBuilder::BuildResponsePdfFile,
+    response_rtf_file_builder: ClaimFileBuilder::BuildResponseRtfFile)
     self.response = response
     self.response_text_file_builder = response_text_file_builder
     self.response_pdf_file_builder = response_pdf_file_builder
+    self.response_rtf_file_builder = response_rtf_file_builder
   end
 
   def call
+    add_file :response_rtf_file, to: response
     add_file :response_text_file, to: response
     add_file :response_pdf_file, to: response
   end
@@ -21,5 +26,5 @@ class ResponseFileBuilderService
     builder.call(to)
   end
 
-  attr_accessor :response, :response_text_file_builder, :response_pdf_file_builder
+  attr_accessor :response, :response_text_file_builder, :response_pdf_file_builder, :response_rtf_file_builder
 end

--- a/app/views/api/v2/s3/signed_urls/create.json.jbuilder
+++ b/app/views/api/v2/s3/signed_urls/create.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.status result.valid? ? 'accepted' : 'invalid'
+json.meta result.meta
+json.uuid result.uuid
+json.data data[:output_values]

--- a/bin/wait-for-it.sh
+++ b/bin/wait-for-it.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec "${CLI[@]}"
+else
+    exit $RESULT
+fi

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,6 @@ module EtApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.s3_direct_upload_bucket = ENV.fetch('S3_DIRECT_UPLOAD_BUCKET')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,6 @@ module EtApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-    config.s3_direct_upload_bucket = ENV.fetch('S3_DIRECT_UPLOAD_BUCKET')
+    config.s3_direct_upload_bucket = ENV.fetch('S3_DIRECT_UPLOAD_BUCKET', 'defaultbucket')
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,8 +29,8 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
   config.action_controller.default_url_options = { host: 'example.com' }
 
-  # Store uploaded files on the local file system in a temporary directory
-  config.active_storage.service = :test
+  # As we do some s3 specific stuff, we have to use an s3 server for testing (local server called minio)
+  config.active_storage.service = :amazon
 
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/event_handlers.rb
+++ b/config/initializers/event_handlers.rb
@@ -1,3 +1,4 @@
 Rails.application.config.after_initialize do
   EventService.subscribe('ResponseCreated', ResponseCreatedHandler)
+  EventService.subscribe('SignedS3FormDataCreated', SignedS3FormDataCreatedHandler)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
       namespace :respondents do
         post "build_response" => 'build_responses#create'
       end
+      namespace :s3 do
+        post 'create_signed_url' => 'signed_urls#create'
+      end
     end
   end
   mount EtAtosFileTransfer::Engine, at: '/atos_api'

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -13,20 +13,37 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DATABASE: 1
+      S3_DIRECT_UPLOAD_BUCKET: 'etapidirectbucket'
+
     volumes:
       - ../..:/app
       - rubygems_cache:/usr/local/bundle
     ports:
       - ${PORT:-0}:8080
+    networks:
+      - api
 
   db:
     image: postgres:9.3.5
     ports:
       - '${DB_PORT:-0}:5432'
+    networks:
+      - api
   redis:
     image: redis
     ports:
       - ${REDIS_PORT:-0}:6379
-
+    networks:
+      - api
+  s3_mock:
+    image: scality/s3server
+    networks:
+      api:
+        aliases:
+          - "s3.docker.test"
+    ports:
+      - "${S3_PORT:-0}:8000"
 volumes:
   rubygems_cache:
+networks:
+  api:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,29 +1,5 @@
 version: '3'
 services:
-  dev:
-    build:
-      context: .
-    links:
-      - db
-      - minio
-    environment:
-      RAILS_ENV:
-      DB_HOST: db
-      DB_USERNAME: postgres
-      BUNDLE_WITHOUT: production
-      REDIS_HOST: redis
-      REDIS_PORT: 6379
-      REDIS_DATABASE: 1
-      S3_DIRECT_UPLOAD_BUCKET: 'etapidirectbucket'
-
-    volumes:
-      - ../..:/app
-      - rubygems_cache:/usr/local/bundle
-    ports:
-      - ${PORT:-0}:8080
-    networks:
-      - api
-
   db:
     image: postgres:9.3.5
     ports:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
     links:
       - db
+      - minio
     environment:
       RAILS_ENV:
       DB_HOST: db
@@ -35,15 +36,20 @@ services:
       - ${REDIS_PORT:-0}:6379
     networks:
       - api
-  s3_mock:
-    image: scality/s3server
-    networks:
-      api:
-        aliases:
-          - "s3.docker.test"
+  minio:
+    image: minio/minio
+    volumes:
+      - minio_data:/export
     ports:
-      - "${S3_PORT:-0}:8000"
+      - ${S3_PORT:-0}:9000
+    environment:
+      MINIO_ACCESS_KEY: accessKey1
+      MINIO_SECRET_KEY: verySecretKey1
+    command: server minio_data
+
+
 volumes:
   rubygems_cache:
+  minio_data:
 networks:
   api:

--- a/docker/dev/docker-server.yml
+++ b/docker/dev/docker-server.yml
@@ -1,4 +1,26 @@
 version: '3'
 services:
   dev:
+    build:
+      context: .
+    links:
+      - db
+      - minio
+    environment:
+      RAILS_ENV:
+      DB_HOST: db
+      DB_USERNAME: postgres
+      BUNDLE_WITHOUT: production
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DATABASE: 1
+      S3_DIRECT_UPLOAD_BUCKET: 'etapidirectbucket'
+
+    volumes:
+      - ../..:/app
+      - rubygems_cache:/usr/local/bundle
+    ports:
+      - ${PORT:-0}:8080
+    networks:
+      - api
     command: bash -c "bundle && bundle exec rake db:create db:migrate && foreman start"

--- a/spec/commands/create_signed_s3_form_data_command_spec.rb
+++ b/spec/commands/create_signed_s3_form_data_command_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CreateSignedS3FormDataCommand do
   subject(:command) { described_class.new(uuid: uuid, data: data, async: false) }
 
   let(:uuid) { SecureRandom.uuid }
-  let(:data) { { anything: :goes} }
+  let(:data) { { anything: :goes } }
   let(:root_object) { {} }
 
   describe '#apply' do

--- a/spec/commands/create_signed_s3_form_data_command_spec.rb
+++ b/spec/commands/create_signed_s3_form_data_command_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe CreateSignedS3FormDataCommand do
+  subject(:command) { described_class.new(uuid: uuid, data: data, async: false) }
+
+  let(:uuid) { SecureRandom.uuid }
+  let(:data) { { anything: :goes} }
+  let(:root_object) { {} }
+
+  describe '#apply' do
+    it 'applies the data to the root object' do
+      # Act
+      command.apply(root_object)
+
+      # Assert
+      expect(root_object).to include(anything: :goes)
+    end
+  end
+end

--- a/spec/factories/json/json_response_factory.rb
+++ b/spec/factories/json/json_response_factory.rb
@@ -50,22 +50,6 @@ FactoryBot.define do
     end
   end
 
-  #   "case_number": "7654321/2017",
-  #   "name": "dodgy_co",
-  #   "contact": "John Smith",
-  #   "building_name": "the_shard",
-  #   "street_name": "downing_street",
-  #   "town": "westminster",
-  #   "county": "",
-  #   "postcode": "wc1 1aa",
-  #   "dx_number": "",
-  #   "contact_number": "",
-  #   "mobile_number": "",
-  #   "contact_preference": "email",
-  #   "email_address": "john@dodgyco.com",
-  #   "fax_number": "",
-  #
-
   factory :json_response_data, class: ::EtApi::Test::Json::Node do
     trait :minimal do
       case_number '1454321/2017'

--- a/spec/factories/json/json_response_factory.rb
+++ b/spec/factories/json/json_response_factory.rb
@@ -37,6 +37,17 @@ FactoryBot.define do
         ]
       end
     end
+
+    trait :with_rtf do
+      uuid { SecureRandom.uuid }
+      command 'SerialSequence'
+      data do
+        [
+          build(:json_command, uuid: SecureRandom.uuid, command: 'BuildResponse', data: build(:json_response_data, :full, :with_rtf)),
+          build(:json_command, uuid: SecureRandom.uuid, command: 'BuildRespondent', data: build(:json_respondent_data, :full))
+        ]
+      end
+    end
   end
 
   #   "case_number": "7654321/2017",
@@ -90,7 +101,26 @@ FactoryBot.define do
       claim_information "lorem ipsum info"
       email_receipt "email@recei.pt"
     end
+    additional_information_key do
+      next if rtf_file_path.nil?
+      config = {
+        region: ENV.fetch('AWS_REGION', 'us-east-1'),
+        access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID', 'accessKey1'),
+        secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY', 'verySecretKey1'),
+        endpoint: ENV.fetch('AWS_ENDPOINT', 'http://localhost:9000/'),
+        force_path_style: ENV.fetch('AWS_S3_FORCE_PATH_STYLE', 'true') == 'true'
+      }
+      s3 = Aws::S3::Client.new(config)
 
+      bucket = Aws::S3::Bucket.new(client: s3, name: Rails.configuration.s3_direct_upload_bucket)
+      obj = bucket.object(SecureRandom.uuid)
+      obj.put(body: File.read(rtf_file_path), content_type: 'application/rtf')
+      obj.key
+    end
+
+    trait :with_rtf do
+      rtf_file_path { Rails.root.join('spec', 'fixtures', 'example.rtf') }
+    end
   end
 
   factory :json_respondent_data, class: ::EtApi::Test::Json::Node do

--- a/spec/factories/json/json_response_factory.rb
+++ b/spec/factories/json/json_response_factory.rb
@@ -51,6 +51,9 @@ FactoryBot.define do
   end
 
   factory :json_response_data, class: ::EtApi::Test::Json::Node do
+    transient do
+      rtf_file_path nil
+    end
     trait :minimal do
       case_number '1454321/2017'
       agree_with_employment_dates false

--- a/spec/factories/json/json_s3_factory.rb
+++ b/spec/factories/json/json_s3_factory.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
   factory :json_create_signed_s3_url_command, parent: :json_command do
     command 'CreateSignedS3FormData'
     async false
-    data { { key: 'my_key' } }
+    data { {} }
   end
 end

--- a/spec/factories/json/json_s3_factory.rb
+++ b/spec/factories/json/json_s3_factory.rb
@@ -1,0 +1,10 @@
+require 'faker'
+require 'securerandom'
+
+FactoryBot.define do
+  factory :json_create_signed_s3_url_command, parent: :json_command do
+    command 'CreateSignedS3FormData'
+    async false
+    data { { key: 'my_key' } }
+  end
+end

--- a/spec/factories/json/json_s3_factory.rb
+++ b/spec/factories/json/json_s3_factory.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
   factory :json_create_signed_s3_url_command, parent: :json_command do
     command 'CreateSignedS3FormData'
     async false
-    data { {} }
+    data nil
   end
 end

--- a/spec/factories/response_factory.rb
+++ b/spec/factories/response_factory.rb
@@ -48,6 +48,18 @@ FactoryBot.define do
       end
     end
 
+    trait :with_input_rtf_file do
+      after(:build) do |response, _evaluator|
+        response.uploaded_files << build(:uploaded_file, :example_response_input_rtf)
+      end
+    end
+
+    trait :with_wrong_input_rtf_file do
+      after(:build) do |response, _evaluator|
+        response.uploaded_files << build(:uploaded_file, :example_response_wrong_input_rtf)
+      end
+    end
+
     trait :ready_for_export do
       # Ready for export MUST be in the database and files stored - so we dont do build here
       after(:create) do |response, _evaluator|

--- a/spec/factories/uploaded_file_factory.rb
+++ b/spec/factories/uploaded_file_factory.rb
@@ -67,6 +67,22 @@ FactoryBot.define do
       end
     end
 
+    trait :example_response_input_rtf do
+      filename 'additional_information.rtf'
+      checksum 'ee2714b8b731a8c1e95dffaa33f89728'
+      after(:build) do |uploaded_file, _evaluator|
+        uploaded_file.file.attach(Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'example.rtf'), 'application/rtf'))
+      end
+    end
+
+    trait :example_response_wrong_input_rtf do
+      filename 'additional_information.rtf'
+      checksum 'ee2714b8b731a8c1e95dffaa33f89728'
+      after(:build) do |uploaded_file, _evaluator|
+        uploaded_file.file.attach(Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'simple_user_with_rtf.rtf'), 'application/rtf'))
+      end
+    end
+
     # We do not have an example pdf yet - but the file contents does not really matter as nothing is reading it
     trait :example_response_pdf do
       filename 'et3_atos_export.pdf'

--- a/spec/fixtures/example.rtf
+++ b/spec/fixtures/example.rtf
@@ -1,0 +1,19 @@
+{\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch0\stshfloch0\stshfhich0\stshfbi0\deflang2057\deflangfe2057{\fonttbl{\f0\froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f37\froman\fcharset238\fprq2 Times New Roman CE;}{\f38\froman\fcharset204\fprq2 Times New Roman Cyr;}
+{\f40\froman\fcharset161\fprq2 Times New Roman Greek;}{\f41\froman\fcharset162\fprq2 Times New Roman Tur;}{\f42\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f43\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
+{\f44\froman\fcharset186\fprq2 Times New Roman Baltic;}{\f45\froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;
+\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;}
+{\stylesheet{\ql \li0\ri0\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang2057\langfe2057\cgrid\langnp2057\langfenp2057 \snext0 Normal;}{\*\cs10 \additive \ssemihidden 
+Default Paragraph Font;}{\*\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tscellwidthfts0\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv 
+\ql \li0\ri0\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs20 \ltrch\fcs0 \fs20\lang1024\langfe1024\cgrid\langnp1024\langfenp1024 \snext11 \ssemihidden Normal Table;}}
+{\*\latentstyles\lsdstimax156\lsdlockeddef0}{\*\rsidtbl \rsid12452783}{\*\generator Microsoft Word 11.0.0000;}{\info{\title This is a test rtf file}{\author DTHOMPSON1}{\operator DTHOMPSON1}{\creatim\yr2016\mo10\dy14\hr11}{\revtim\yr2016\mo10\dy14\hr11}
+{\version1}{\edmins0}{\nofpages1}{\nofwords3}{\nofchars21}{\*\company Ministry of Justice}{\nofcharsws23}{\vern24617}{\*\password 00000000}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\paperw11906\paperh16838\margl1800\margr1800\margt1440\margb1440\gutter0\ltrsect 
+\widowctrl\ftnbj\aenddoc\donotembedsysfont1\donotembedlingdata0\grfdocevents0\validatexml1\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors1\noxlattoyen\expshrtn\noultrlspc\dntblnsbdb\nospaceforul\formshade\horzdoc\dgmargin\dghspace180
+\dgvspace180\dghorigin1800\dgvorigin1440\dghshow1\dgvshow1
+\jexpand\viewkind1\viewscale100\pgbrdrhead\pgbrdrfoot\splytwnine\ftnlytwnine\htmautsp\nolnhtadjtbl\useltbaln\alntblind\lytcalctblwd\lyttblrtgr\lnbrkrule\nobrkwrptbl\snaptogridincell\allowfieldendsel\wrppunct
+\asianbrkrule\rsidroot12452783\newtblstyruls\nogrowautofit \fet0{\*\wgrffmtfilter 013f}\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\headery708\footery708\colsx708\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\*\pnseclvl1
+\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5
+\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang 
+{\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang2057\langfe2057\cgrid\langnp2057\langfenp2057 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid12452783 This is a test rtf file
+\par }}

--- a/spec/models/exported_file_spec.rb
+++ b/spec/models/exported_file_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe ExportedFile, type: :model do
       end
     end
 
-    it 'returns a local url as we are in test mode' do
+    it 'returns a minio test server url as we are in test mode' do
       exported_file.file = fixture_file
 
-      expect(exported_file.url).to match(%r{\Ahttp:\/\/example.com\/rails\/active_storage\/disk\/.*et1_first_last\.pdf\z})
+      expect(exported_file.url).to start_with(ActiveStorage::Blob.service.bucket.url)
     end
   end
 

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -48,4 +48,22 @@ RSpec.describe Response, type: :model do
       end
     end
   end
+
+  describe '#has_additional_information_rtf_file?' do
+    context 'with an attached file' do
+      subject(:response) { build(:response, :example_data, :with_input_rtf_file) }
+
+      it 'returns true' do
+        expect(response.has_additional_information_rtf_file?).to be true
+      end
+    end
+
+    context 'with no attached file' do
+      subject(:response) { build(:response, :example_data) }
+
+      it 'returns false' do
+        expect(response.has_additional_information_rtf_file?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Response, type: :model do
+  subject(:response) { described_class.new }
+
+  describe '#additional_information_url=' do
+    let(:rtf_file_path) { Rails.root.join('spec', 'fixtures', 'example.rtf').to_s }
+    # The json_response_data factory is being used just to generate a remote file - nothing else - saves duplicating that code
+    let(:remote_key) do
+      FactoryBot.build(:json_response_data, :with_rtf, rtf_file_path: rtf_file_path).additional_information_key
+    end
+
+    it 'imports a remote file into a new imported file named as the rtf file if it doesnt already exist' do
+      # Act - Assign the remote url
+      response.additional_information_key = remote_key
+
+      # Assert - ensure an uploaded file has been built
+      expect(response.uploaded_files.detect { |f| f.filename == 'additional_information.rtf' }.try(:file)).to be_a_stored_file_with_contents(File.read(rtf_file_path))
+    end
+
+    it 'does nothing if the new value is nil and the rtf file doesnt already exist' do
+      # Act - Assign the remote url
+      response.additional_information_key = nil
+
+      # Assert - ensure an uploaded file has not been built
+      expect(response.uploaded_files.length).to be 0
+    end
+
+    context 'with existing file' do
+      subject(:response) { build(:response, :with_wrong_input_rtf_file) }
+
+      it 'imports a remote file into an existing imported file if it already exist based on a set filename' do
+        # Act - Assign the remote url
+        response.additional_information_key = remote_key
+
+        # Assert - ensure an uploaded file has been built
+        expect(response.uploaded_files.detect { |f| f.filename == 'additional_information.rtf' }.try(:file)).to be_a_stored_file_with_contents(File.read(rtf_file_path))
+      end
+
+      it 'removes an imported file if it already exist based on a set filename and the new value is nil' do
+        # Act - Assign the remote url
+        response.additional_information_key = nil
+
+        # Assert - ensure an uploaded file has been removed
+        expect(response.uploaded_files.length).to be 0
+      end
+    end
+  end
+end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe Response, type: :model do
     end
   end
 
-  describe '#has_additional_information_rtf_file?' do
+  describe '#additional_information_rtf_file?' do
     context 'with an attached file' do
       subject(:response) { build(:response, :example_data, :with_input_rtf_file) }
 
       it 'returns true' do
-        expect(response.has_additional_information_rtf_file?).to be true
+        expect(response.additional_information_rtf_file?).to be true
       end
     end
 
@@ -62,7 +62,7 @@ RSpec.describe Response, type: :model do
       subject(:response) { build(:response, :example_data) }
 
       it 'returns false' do
-        expect(response.has_additional_information_rtf_file?).to be false
+        expect(response.additional_information_rtf_file?).to be false
       end
     end
   end

--- a/spec/models/uploaded_file_spec.rb
+++ b/spec/models/uploaded_file_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe UploadedFile, type: :model do
         ActiveStorage::Current.host = old_value
       end
     end
-    it 'returns a local url as we are in test mode' do
+    it 'returns a minio server url as we are in test mode' do
       uploaded_file.file = fixture_file
 
-      expect(uploaded_file.url).to match(%r{\Ahttp:\/\/example.com\/rails\/active_storage\/disk\/.*et1_first_last\.pdf\z})
+      expect(uploaded_file.url).to start_with(ActiveStorage::Blob.service.bucket.url)
     end
   end
 

--- a/spec/requests/create_signed_s3_url_spec.rb
+++ b/spec/requests/create_signed_s3_url_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Create signed S3 url request', type: :request do
+  describe 'POST /api/v2/s3/create_signed_url' do
+    let(:default_headers) do
+      {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      }
+    end
+    let(:errors) { [] }
+    let(:json_response) { JSON.parse(response.body).with_indifferent_access }
+
+    it 'provides a response with the data in it' do
+      # Arrange - build the data
+      json_factory = FactoryBot.build(:json_create_signed_s3_url_command)
+      json_data = json_factory.to_json
+
+      # Act - Make the request
+      post '/api/v2/s3/create_signed_url', params: json_data, headers: default_headers
+
+      # Assert - Make sure the data is in the response
+      expect(json_response).to include data: a_hash_including(fields: {
+        key: "direct_uploads/#{json_factory.data[:key]}",
+        acl: instance_of(String),
+        success_action_redirect: a_string_ending_with('successful_upload.html'),
+        'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+        'X-Amz-Credential': a_string_matching(/\A[^\/]*\/\d{8}\/s3\/aws4_request\z/),
+        'X-Amz-Date': a_string_matching(/\A\d{8}T\d{6}Z\z/),
+        'x-amz-meta-uuid': instance_of(String),
+        'x-amz-server-side-encryption': 'AES256',
+        'x-amz-meta-tag': '',
+        Policy: instance_of(String),
+        'X-Amz-Signature': instance_of(String)
+      })
+    end
+
+    it 'provides a response with the post url in it' do
+      # Arrange - build the data
+      json_factory = FactoryBot.build(:json_create_signed_s3_url_command)
+      json_data = json_factory.to_json
+
+      # Act - Make the request
+      post '/api/v2/s3/create_signed_url', params: json_data, headers: default_headers
+
+      # Assert - Make sure the data is in the response
+      expect(json_response).to include data: a_hash_including(url: instance_of(String))
+    end
+  end
+end

--- a/spec/requests/create_signed_s3_url_spec.rb
+++ b/spec/requests/create_signed_s3_url_spec.rb
@@ -22,19 +22,13 @@ RSpec.describe 'Create signed S3 url request', type: :request do
       post '/api/v2/s3/create_signed_url', params: json_data, headers: default_headers
 
       # Assert - Make sure the data is in the response
-      expect(json_response).to include data: a_hash_including(fields: {
-        key: "direct_uploads/#{json_factory.data[:key]}",
-        acl: instance_of(String),
-        success_action_redirect: a_string_ending_with('successful_upload.html'),
-        'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
-        'X-Amz-Credential': a_string_matching(/\A[^\/]*\/\d{8}\/s3\/aws4_request\z/),
-        'X-Amz-Date': a_string_matching(/\A\d{8}T\d{6}Z\z/),
-        'x-amz-meta-uuid': instance_of(String),
-        'x-amz-server-side-encryption': 'AES256',
-        'x-amz-meta-tag': '',
-        Policy: instance_of(String),
-        'X-Amz-Signature': instance_of(String)
-      })
+      expect(json_response.dig(:data, :fields).symbolize_keys).to include key: starting_with("direct_uploads/"),
+                                                                          'x-amz-algorithm': 'AWS4-HMAC-SHA256',
+                                                                          'x-amz-credential': a_string_matching(%r{\A[^\/]*\/\d{8}\/us-east-1\/s3\/aws4_request\z}),
+                                                                          'x-amz-date': match_regex(/\A\d{8}T\d{6}Z\z/),
+                                                                          policy: instance_of(String),
+                                                                          'x-amz-signature': instance_of(String)
+
     end
 
     it 'provides a response with the post url in it' do

--- a/spec/services/claim_file_builder/build_response_pdf_file_spec.rb
+++ b/spec/services/claim_file_builder/build_response_pdf_file_spec.rb
@@ -46,5 +46,11 @@ RSpec.describe ClaimFileBuilder::BuildResponsePdfFile do
 
       include_examples 'for any response variation'
     end
+
+    context 'with an attached rtf file' do
+      let(:response) { build(:response, :example_data, :with_input_rtf_file) }
+
+      include_examples 'for any response variation'
+    end
   end
 end

--- a/spec/services/claim_file_builder/build_response_rtf_file_spec.rb
+++ b/spec/services/claim_file_builder/build_response_rtf_file_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe ClaimFileBuilder::BuildResponseRtfFile do
+  subject(:builder) { described_class }
+
+  let(:errors) { [] }
+
+  describe '#call' do
+    let(:response) { build(:response, :with_input_rtf_file) }
+
+    it 'stores an ET3 response file with the correct filename' do
+      # Act
+      builder.call(response)
+
+      # Assert
+      expect(response.uploaded_files).to include an_object_having_attributes filename: 'et3_atos_export.rtf',
+                                                                             file: be_a_stored_file
+    end
+
+    it 'stores an ET3 response file which is a copy of the original' do
+      # Act
+      builder.call(response)
+      response.save!
+
+      # Assert
+      uploaded_file = response.uploaded_files.where(filename: 'et3_atos_export.rtf').first
+      Dir.mktmpdir do |dir|
+        original_path = File.join(dir, 'original.rtf')
+        original_file = response.uploaded_files.detect { |f| f.filename == 'additional_information.rtf' }
+
+        full_path = File.join(dir, 'et3_atos_export.rtf')
+        uploaded_file.download_blob_to(full_path)
+        original_file.download_blob_to(original_path)
+        File.open full_path do |file|
+          expect(file).to be_a_file_copy_of(original_path)
+        end
+      end
+    end
+
+    context 'with no input rtf file' do
+      let(:response) { build(:response) }
+
+      it 'succeeds but does nothing if no input rtf file' do
+        # Act
+        builder.call(response)
+
+        # Assert
+        expect(response.uploaded_files).to be_empty
+      end
+    end
+
+  end
+end

--- a/spec/services/export_service_spec.rb
+++ b/spec/services/export_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ExportService do
     end
 
     let!(:responses) do
-      create_list(:response, 2, :with_pdf_file, :with_text_file, :ready_for_export)
+      create_list(:response, 2, :with_pdf_file, :with_text_file, :with_rtf_file, :ready_for_export)
     end
 
     it 'produces an ExportedFile' do
@@ -84,6 +84,18 @@ RSpec.describe ExportService do
 
       # Assert
       expected_filenames = responses.map { |c| "#{c.reference}_ET3_.txt" }
+      expect(EtApi::Test::StoredZipFile.file_names(zip: ExportedFile.last)).to include(*expected_filenames)
+    end
+
+    it 'produces a zip file that contains an rtf file for each response' do
+      # Act
+      service.export
+
+      # Assert
+      expected_filenames = responses.map do |r|
+        company_name_underscored = r.respondent.name.split(/\W/).join('_')
+        "#{r.reference}_ET3_Attachment_#{company_name_underscored}.rtf"
+      end
       expect(EtApi::Test::StoredZipFile.file_names(zip: ExportedFile.last)).to include(*expected_filenames)
     end
 

--- a/spec/services/response_file_builder_service_spec.rb
+++ b/spec/services/response_file_builder_service_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe ResponseFileBuilderService do
   subject(:service) do
     described_class.new response,
       response_text_file_builder: response_text_file_builder_spy,
-      response_pdf_file_builder: response_pdf_file_builder_spy
+      response_pdf_file_builder: response_pdf_file_builder_spy,
+      response_rtf_file_builder: response_rtf_file_builder_spy
 
   end
 
@@ -12,6 +13,7 @@ RSpec.describe ResponseFileBuilderService do
   # Spies for the builders which return nothing
   let(:response_text_file_builder_spy) { class_spy('ClaimFileBuilder::BuildResponseTextFile') }
   let(:response_pdf_file_builder_spy) { class_spy('ClaimFileBuilder::BuildResponsePdfFile') }
+  let(:response_rtf_file_builder_spy) { class_spy('ClaimFileBuilder::BuildResponseRtfFile') }
 
   describe '#call' do
     let(:response) { build(:response) }
@@ -32,9 +34,31 @@ RSpec.describe ResponseFileBuilderService do
       expect(response_pdf_file_builder_spy).to have_received(:call)
     end
 
+    it 'calls the response rtf file builder' do
+      # Act
+      service.call
+
+      # Assert
+      expect(response_rtf_file_builder_spy).to have_received(:call)
+    end
+
     it 'has the correct default builder for the pdf file' do
       # Arrange - Setup a spy on the expected class - and stub its constant
       expected_class = class_spy('ClaimFileBuilder::BuildResponsePdfFile').as_stubbed_const
+      service = described_class.new response
+
+      # Act
+      service.call
+
+      # Assert
+      expect(expected_class).to have_received(:call)
+    end
+
+    it 'has the correct default builder for the rtf file' do
+      # Arrange - Setup a spy on the expected class - and stub its constant
+      class_spy('ClaimFileBuilder::BuildResponseTextFile').as_stubbed_const
+      class_spy('ClaimFileBuilder::BuildResponsePdfFile').as_stubbed_const
+      expected_class = class_spy('ClaimFileBuilder::BuildResponseRtfFile').as_stubbed_const
       service = described_class.new response
 
       # Act

--- a/spec/support/helpers/s3_helper.rb
+++ b/spec/support/helpers/s3_helper.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |c|
+  c.before s3_server: true do
+    EtApi::Test::S3Helper.new
+  end
+end

--- a/spec/support/landing_folder_support/file_objects/et3_pdf_file.rb
+++ b/spec/support/landing_folder_support/file_objects/et3_pdf_file.rb
@@ -3,30 +3,6 @@ require_relative '../../helpers/office_helper'
 module EtApi
   module Test
     module FileObjects
-      # Represents the ET3 PDF file and provides assistance in validating its contents
-=begin
-  ["case number", "date_received", "RTF", "1.1", "2.3 postcode", "2.1", "2.2",
-  "2.3 number or name", "2.3 street", "2.3 town city", "2.3 county",
-  "2.3 dx number", "2.4 phone number", "2.4 mobile number", "2.5", "2.6 email address", "2.6 fax number",
-  "2.7", "2.8", "2.9",
-  "3.1", "3.1 employment started", "3.1 employment end", "3.1 disagree",
-  "3.2", "3.3", "3.3 if no",
-  "4.1", "4.1 if no", "4.2", "4.2 pay before tax", "4.2 pay before tax tick box", "4.2 normal take-home pay", "4.2 normal take-home pay tick box", "4.3 tick box", "4.3 if no", "4.4 tick box", "4.4 if no",
-  "5.1 tick box", "5.1 if yes",
-  "6.2 tick box", "6.3", "7.3 postcode",
-  "7.1", "7.2", "7.3 number or name", "7.3 street", "7.3 town city", "7.3 county", "7.4", "7.5 phone number", "7.6", "7.7", "7.8 tick box", "7.9", "7.10",
-  "8.1 tick box", "8.1 if yes", "8.1 please re-read", "additional space for notes", "new 3.1", "new 3.1 If no, please explain why"]
-=end
-=begin
- mappings:
-
-  3.2 => 4.2 (yes, no)
-  3.3 => 4.3 (yes, no)
-
-email_receipt does not go to pdf
-representative_type does not go to pdf
-
-=end
       class Et3PdfFile < Base # rubocop:disable Metrics/ClassLength
         include RSpec::Matchers
 

--- a/spec/support/landing_folder_support/file_objects/et3_pdf_file.rb
+++ b/spec/support/landing_folder_support/file_objects/et3_pdf_file.rb
@@ -28,13 +28,14 @@ module EtApi
           representative = response.representative.try(:as_json, include: :address).try(:symbolize_keys)
           respondent[:address_attributes] = respondent.delete(:address).symbolize_keys
           representative[:address_attributes] = representative.delete(:address).symbolize_keys unless representative.nil?
-          response = response.as_json.symbolize_keys
+          response = response.as_json.symbolize_keys.merge(additional_information_key: response.has_additional_information_rtf_file? ? 'canbeanything' : nil)
           has_correct_contents_for?(response: response, respondent: respondent, representative: representative, errors: errors, indent: indent)
         end
 
         def has_header_for?(response, errors: [], indent: 1)
           validate_fields section: :header, errors: errors, indent: indent do
             expect(field_values).to include 'case number' => response[:case_number] || ''
+            expect(field_values).to include 'RTF' => response[:additional_information_key].blank? ? '' : 'Additional RTF'
           end
         end
 

--- a/spec/support/landing_folder_support/file_objects/et3_pdf_file.rb
+++ b/spec/support/landing_folder_support/file_objects/et3_pdf_file.rb
@@ -28,7 +28,7 @@ module EtApi
           representative = response.representative.try(:as_json, include: :address).try(:symbolize_keys)
           respondent[:address_attributes] = respondent.delete(:address).symbolize_keys
           representative[:address_attributes] = representative.delete(:address).symbolize_keys unless representative.nil?
-          response = response.as_json.symbolize_keys.merge(additional_information_key: response.has_additional_information_rtf_file? ? 'canbeanything' : nil)
+          response = response.as_json.symbolize_keys.merge(additional_information_key: response.additional_information_rtf_file? ? 'canbeanything' : nil)
           has_correct_contents_for?(response: response, respondent: respondent, representative: representative, errors: errors, indent: indent)
         end
 

--- a/spec/support/landing_folder_support/staging_folder.rb
+++ b/spec/support/landing_folder_support/staging_folder.rb
@@ -63,10 +63,6 @@ module EtApi
         EtApi::Test::FileObjects::Et3TxtFile.new extract_to_tempfile(filename)
       end
 
-      def et3_txt_file(filename)
-        EtApi::Test::FileObjects::Et3TxtFile.new extract_to_tempfile(filename)
-      end
-
       def et3_pdf_file(filename)
         EtApi::Test::FileObjects::Et3PdfFile.new extract_to_tempfile(filename)
       end

--- a/spec/support/setup_buckets.rb
+++ b/spec/support/setup_buckets.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |c|
+  c.before(:suite) do
+    config = {
+      region: ENV.fetch('AWS_REGION', 'us-east-1'),
+      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID', 'accessKey1'),
+      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY', 'verySecretKey1'),
+      endpoint: ENV.fetch('AWS_ENDPOINT', 'http://localhost:9000/'),
+      force_path_style: ENV.fetch('AWS_S3_FORCE_PATH_STYLE', 'true') == 'true'
+    }
+    s3 = Aws::S3::Client.new(config)
+    Aws::S3::Bucket.new(client: s3, name: ActiveStorage::Blob.service.bucket.name).tap do |bucket|
+      bucket.create unless bucket.exists?
+      bucket.objects.each(&:delete)
+    end
+    Aws::S3::Bucket.new(client: s3, name: Rails.configuration.s3_direct_upload_bucket).tap do |bucket|
+      bucket.create unless bucket.exists?
+      bucket.objects.each(&:delete)
+    end
+
+  end
+end


### PR DESCRIPTION
This PR implements a mechanism used by the 'additional info' rtf file in ET3 where the front end application can do direct uploads to S3 rather than via the API.
The API then receives the 'key' of the file in the bucket as part of the submission data where it then copies it to the appropriate place and the file is stored alongside the submission.

The ethos exporter then adds this rtf file to the exported file.

Note that as we are now doing custom S3 code within the application rather than relying on active storage for everything, then we are having to use minio as part of the test suite rather than the test adapter for active storage.  This is an improvement anyway as we are testing real code.
