### PR TITLE
PDF File generation now deals with optional data

### DIFF
--- a/app/services/claim_file_builder/build_response_pdf_file.rb
+++ b/app/services/claim_file_builder/build_response_pdf_file.rb
@@ -56,6 +56,11 @@ module ClaimFileBuilder
       result
     end
 
+    def tri_state_value_for(value, yes: 'yes', no: 'no', off: 'Off')
+      return off if value.nil?
+      value ? yes : no
+    end
+
     def apply_header_pdf_fields(result)
       result['case number'] = response.case_number
       result['RTF'] = response.additional_information_rtf_file? ? 'Additional RTF' : ''
@@ -78,7 +83,7 @@ module ClaimFileBuilder
       result['2.3 dx number'] = respondent.dx_number
       result['2.4 phone number'] = respondent.address_telephone_number
       result['2.4 mobile number'] = respondent.alt_phone_number
-      result['2.5'] = respondent.contact_preference
+      result['2.5'] = respondent.contact_preference || 'Off'
       result['2.6 email address'] = respondent.email_address
       result['2.6 fax number'] = respondent.fax_number
       result['2.7'] = respondent.organisation_employ_gb
@@ -97,21 +102,21 @@ module ClaimFileBuilder
       result['3.1 employment end'] = response.employment_end.try(:strftime, '%d/%m/%Y')
       result['3.1 disagree'] = response.disagree_employment
       result['3.2'] = response.continued_employment ? 'yes' : 'no'
-      result['3.3'] = response.agree_with_claimants_description_of_job_or_title ? 'yes' : 'no'
+      result['3.3'] = tri_state_value_for(response.agree_with_claimants_description_of_job_or_title)
       result['3.3 if no'] = response.disagree_claimants_job_or_title ? 'yes' : 'no'
     end
 
     def apply_earnings_pdf_fields(result)
-      result['4.1'] = response.agree_with_claimants_hours ? 'yes' : 'no'
+      result['4.1'] = tri_state_value_for(response.agree_with_claimants_hours)
       result['4.1 if no'] = response.queried_hours
-      result['4.2'] = response.agree_with_earnings_details ? 'yes' : 'no'
+      result['4.2'] = tri_state_value_for(response.agree_with_earnings_details)
       result['4.2 pay before tax'] = response.queried_pay_before_tax
-      result['4.2 pay before tax tick box'] = response.queried_pay_before_tax_period.try(:downcase)
+      result['4.2 pay before tax tick box'] = response.queried_pay_before_tax_period.try(:downcase) || 'Off'
       result['4.2 normal take-home pay'] = response.queried_take_home_pay
-      result['4.2 normal take-home pay tick box'] = response.queried_take_home_pay_period.try(:downcase)
-      result['4.3 tick box'] = response.agree_with_claimant_notice ? 'yes' : 'no'
+      result['4.2 normal take-home pay tick box'] = response.queried_take_home_pay_period.try(:downcase) || 'Off'
+      result['4.3 tick box'] = tri_state_value_for(response.agree_with_claimant_notice)
       result['4.3 if no'] = response.disagree_claimant_notice_reason
-      result['4.4 tick box'] = response.agree_with_claimant_pension_benefits ? 'yes' : 'no'
+      result['4.4 tick box'] = tri_state_value_for(response.agree_with_claimant_pension_benefits)
       result['4.4 if no'] = response.disagree_claimant_pension_benefits_reason
     end
 
@@ -140,7 +145,7 @@ module ClaimFileBuilder
       result['7.5 phone number'] = representative.address_telephone_number
       result['7.6'] = representative.mobile_number
       result['7.7'] = representative.reference
-      result['7.8 tick box'] = representative.contact_preference
+      result['7.8 tick box'] = representative.contact_preference || 'Off'
       result['7.9'] = representative.email_address
       result['7.10'] = representative.fax_number
     end
@@ -157,7 +162,7 @@ module ClaimFileBuilder
       result['7.5 phone number'] = ''
       result['7.6'] = ''
       result['7.7'] = ''
-      result['7.8 tick box'] = ''
+      result['7.8 tick box'] = 'Off'
       result['7.9'] = ''
       result['7.10'] = ''
     end
@@ -166,12 +171,12 @@ module ClaimFileBuilder
       representative = response.representative
       return apply_no_disability_pdf_fields(result) if representative.nil?
       return if representative.nil?
-      result['8.1 tick box'] = representative.disability ? 'yes' : 'no'
+      result['8.1 tick box'] = tri_state_value_for(representative.disability)
       result['8.1 if yes'] = representative.disability_information
     end
 
     def apply_no_disability_pdf_fields(result)
-      result['8.1 tick box'] = 'no'
+      result['8.1 tick box'] = 'Off'
       result['8.1 if yes'] = ''
     end
   end

--- a/spec/factories/representative_factory.rb
+++ b/spec/factories/representative_factory.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
       contact_preference 'email'
       fax_number '02222 222222'
       disability_information ''
+      disability false
     end
   end
 end

--- a/spec/factories/respondent_factory.rb
+++ b/spec/factories/respondent_factory.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
       dx_number 'dx1234567890'
       fax_number '02222 222222'
       organisation_employ_gb 10
+      organisation_more_than_one_site true
       employment_at_site_number 5
     end
   end

--- a/spec/factories/response_factory.rb
+++ b/spec/factories/response_factory.rb
@@ -14,8 +14,15 @@ FactoryBot.define do
     queried_hours 30
     disagree_claimant_notice_reason ''
     disagree_claimant_pension_benefits_reason ''
+    defend_claim false
     defend_claim_facts ''
     claim_information ''
+    agree_with_employment_dates true
+    agree_with_claimants_description_of_job_or_title true
+    agree_with_claimants_hours true
+    agree_with_earnings_details true
+    agree_with_claimant_notice true
+    agree_with_claimant_pension_benefits true
 
     sequence :reference do |n|
       "22#{20000000 + n}00"

--- a/spec/support/landing_folder_support/file_objects/et3_pdf_file.rb
+++ b/spec/support/landing_folder_support/file_objects/et3_pdf_file.rb
@@ -58,11 +58,11 @@ module EtApi
             expect(field_values).to include '2.3 dx number' => respondent[:dx_number] || ''
             expect(field_values).to include '2.4 phone number' => respondent[:address_telephone_number] || ''
             expect(field_values).to include '2.4 mobile number' => respondent[:alt_phone_number] || ''
-            expect(field_values).to include '2.5' => respondent[:contact_preference] || ''
+            expect(field_values).to include '2.5' => respondent[:contact_preference] || 'Off'
             expect(field_values).to include '2.6 email address' => respondent[:email_address] || ''
             expect(field_values).to include '2.6 fax number' => respondent[:fax_number] || ''
             expect(field_values).to include '2.7' => respondent[:organisation_employ_gb].to_s
-            expect(field_values).to include '2.8' => respondent[:organisation_more_than_one_site] ? 'yes' : 'no'
+            expect(field_values).to include '2.8' => tri_state_value_for(respondent[:organisation_more_than_one_site])
             expect(field_values).to include '2.9' => respondent[:employment_at_site_number].to_s
           end
         end
@@ -76,35 +76,35 @@ module EtApi
 
         def has_employment_details_for?(response, errors: [], indent: 1)
           validate_fields section: :employment, errors: errors, indent: indent do
-            expect(field_values).to include '3.1' => response[:agree_with_employment_dates] ? 'yes' : 'no'
+            expect(field_values).to include '3.1' => tri_state_value_for(response[:agree_with_employment_dates])
             expect(field_values).to include '3.1 employment started' => response[:employment_start].nil? ? '' : date_for(response[:employment_start])
             expect(field_values).to include '3.1 employment end' => response[:employment_end].nil? ? '' : date_for(response[:employment_end])
             expect(field_values).to include '3.1 disagree' => response[:disagree_employment] || ''
             expect(field_values).to include '3.2' => response[:continued_employment] ? 'yes' : 'no'
-            expect(field_values).to include '3.3' => response[:agree_with_claimants_description_of_job_or_title] ? 'yes' : 'no'
+            expect(field_values).to include '3.3' => tri_state_value_for(response[:agree_with_claimants_description_of_job_or_title])
             expect(field_values).to include '3.3 if no' => response[:disagree_claimants_job_or_title] ? 'yes' : 'no'
           end
         end
 
         def has_earnings_for?(response, errors: [], indent: 1)
           validate_fields section: :earnings, errors: errors, indent: indent do
-            expect(field_values).to include '4.1' => response[:agree_with_claimants_hours] ? 'yes' : 'no'
+            expect(field_values).to include '4.1' => tri_state_value_for(response[:agree_with_claimants_hours])
             expect(field_values).to include '4.1 if no' => decimal_for(response[:queried_hours])
-            expect(field_values).to include '4.2' => response[:agree_with_earnings_details] ? 'yes' : 'no'
+            expect(field_values).to include '4.2' => tri_state_value_for(response[:agree_with_earnings_details])
             expect(field_values).to include '4.2 pay before tax' => decimal_for(response[:queried_pay_before_tax])
-            expect(field_values).to include '4.2 pay before tax tick box' => response[:queried_pay_before_tax_period].try(:downcase) || ''
+            expect(field_values).to include '4.2 pay before tax tick box' => response[:queried_pay_before_tax_period].try(:downcase) || 'Off'
             expect(field_values).to include '4.2 normal take-home pay' => decimal_for(response[:queried_take_home_pay])
-            expect(field_values).to include '4.2 normal take-home pay tick box' => response[:queried_take_home_pay_period].try(:downcase) || ''
-            expect(field_values).to include '4.3 tick box' => response[:agree_with_claimant_notice] ? 'yes' : 'no'
+            expect(field_values).to include '4.2 normal take-home pay tick box' => response[:queried_take_home_pay_period].try(:downcase) || 'Off'
+            expect(field_values).to include '4.3 tick box' => tri_state_value_for(response[:agree_with_claimant_notice])
             expect(field_values).to include '4.3 if no' => response[:disagree_claimant_notice_reason] || ''
-            expect(field_values).to include '4.4 tick box' => response[:agree_with_claimant_pension_benefits] ? 'yes' : 'no'
+            expect(field_values).to include '4.4 tick box' => tri_state_value_for(response[:agree_with_claimant_pension_benefits])
             expect(field_values).to include '4.4 if no' => response[:disagree_claimant_pension_benefits_reason] || ''
           end
         end
 
         def has_response_for?(response, errors: [], indent: 1)
           validate_fields section: :response, errors: errors, indent: indent do
-            expect(field_values).to include '5.1 tick box' => response[:defend_claim] ? 'yes' : 'no'
+            expect(field_values).to include '5.1 tick box' => tri_state_value_for(response[:defend_claim])
             expect(field_values).to include '5.1 if yes' => response[:defend_claim_facts] || ''
           end
         end
@@ -132,7 +132,7 @@ module EtApi
             expect(field_values).to include '7.5 phone number' => representative[:address_telephone_number] || ''
             expect(field_values).to include '7.6' => representative[:mobile_number] || ''
             expect(field_values).to include '7.7' => representative[:reference] || ''
-            expect(field_values).to include '7.8 tick box' => representative[:contact_preference] || ''
+            expect(field_values).to include '7.8 tick box' => representative[:contact_preference] || 'Off'
             expect(field_values).to include '7.9' => representative[:email_address] || ''
             expect(field_values).to include '7.10' => representative[:fax_number] || ''
           end
@@ -151,7 +151,7 @@ module EtApi
             expect(field_values).to include '7.5 phone number' => ''
             expect(field_values).to include '7.6' => ''
             expect(field_values).to include '7.7' => ''
-            expect(field_values).to include '7.8 tick box' => ''
+            expect(field_values).to include '7.8 tick box' => 'Off'
             expect(field_values).to include '7.9' => ''
             expect(field_values).to include '7.10' => ''
           end
@@ -160,14 +160,14 @@ module EtApi
         def has_disability_for?(representative, errors: [], indent: 1)
           return has_no_disability?(errors: errors, indent: indent) if representative.nil?
           validate_fields section: :disability, errors: errors, indent: indent do
-            expect(field_values).to include '8.1 tick box' => representative[:disability] ? 'yes' : 'no'
+            expect(field_values).to include '8.1 tick box' => tri_state_value_for(representative[:disability])
             expect(field_values).to include '8.1 if yes' => representative[:disability_information] || ''
           end
         end
 
         def has_no_disability?(errors: [], indent: 1)
           validate_fields section: :disability, errors: errors, indent: indent do
-            expect(field_values).to include '8.1 tick box' => 'no'
+            expect(field_values).to include '8.1 tick box' => 'Off'
             expect(field_values).to include '8.1 if yes' => ''
           end
         end
@@ -175,6 +175,16 @@ module EtApi
         private
 
         attr_accessor :tempfile
+
+        def tri_state_value_for(value, yes: 'yes', no: 'no', nil_value: 'Off')
+          if value.nil?
+            nil_value
+          elsif value
+            yes
+          else
+            no
+          end
+        end
 
         def field_values
           @field_values ||= form.fields.inject({}) do |acc, field|


### PR DESCRIPTION
The PDF file generation for ET3 now fills in all tri state fields correctly (where there is an 'unset' value) when fields are omitted from the front end data (RST-1198)