### PR TITLE
RST-1164 ET3 Output Filename Correction

### DIFF
--- a/app/services/export_service_exporters/response_exporter.rb
+++ b/app/services/export_service_exporters/response_exporter.rb
@@ -33,7 +33,7 @@ module ExportServiceExporters
 
     def export_file(response:, to:, ext:, type:)
       stored_file = response_export_service.new(response).send(:"export_#{type}")
-      company_name_underscored = response.respondent.name.split(/\W/).join('_')
+      company_name_underscored = response.respondent.name.parameterize(separator: '_', preserve_case: true)
       fn = "#{response.reference}_ET3_#{company_name_underscored}.#{ext}"
       stored_file.download_blob_to File.join(to, fn)
     end
@@ -41,7 +41,7 @@ module ExportServiceExporters
     def export_file_as_attachment(response:, to:, ext:, type:, optional: false)
       stored_file = response_export_service.new(response).send(:"export_#{type}")
       return if optional && stored_file.nil?
-      company_name_underscored = response.respondent.name.split(/\W/).join('_')
+      company_name_underscored = response.respondent.name.parameterize(separator: '_', preserve_case: true)
       fn = "#{response.reference}_ET3_Attachment_#{company_name_underscored}.#{ext}"
       stored_file.download_blob_to File.join(to, fn)
     end

--- a/app/services/export_service_exporters/response_exporter.rb
+++ b/app/services/export_service_exporters/response_exporter.rb
@@ -33,7 +33,8 @@ module ExportServiceExporters
 
     def export_file(response:, to:, ext:, type:)
       stored_file = response_export_service.new(response).send(:"export_#{type}")
-      fn = "#{response.reference}_ET3_.#{ext}"
+      company_name_underscored = response.respondent.name.split(/\W/).join('_')
+      fn = "#{response.reference}_ET3_#{company_name_underscored}.#{ext}"
       stored_file.download_blob_to File.join(to, fn)
     end
 

--- a/spec/requests/create_response_spec.rb
+++ b/spec/requests/create_response_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe 'Create Response Request', type: :request do
         ClaimsExportWorker.new.perform
       end
 
+      def formatted_name_for_filename(text)
+        text.split(/\W/).join('_')
+      end
+
       let(:staging_folder) do
         session = create_session(app)
         actions = {
@@ -127,14 +131,16 @@ RSpec.describe 'Create Response Request', type: :request do
       it 'creates a valid txt file in the correct place in the landing folder' do
         # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
         reference = json_response.dig(:meta, 'BuildResponse', :reference)
-        output_filename_txt = "#{reference}_ET3_.txt"
+        respondent_name = input_respondent_factory.name
+        output_filename_txt = "#{reference}_ET3_#{formatted_name_for_filename(respondent_name)}.txt"
         expect(staging_folder.et3_txt_file(output_filename_txt)).to have_correct_file_structure(errors: errors)
       end
 
       it 'creates a valid txt file with correct header data' do
         # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
         reference = json_response.dig(:meta, 'BuildResponse', :reference)
-        output_filename_txt = "#{reference}_ET3_.txt"
+        respondent_name = input_respondent_factory.name
+        output_filename_txt = "#{reference}_ET3_#{formatted_name_for_filename(respondent_name)}.txt"
         expect(staging_folder.et3_txt_file(output_filename_txt)).to have_correct_contents_for(
           response: input_response_factory,
           respondent: input_respondent_factory,
@@ -146,7 +152,8 @@ RSpec.describe 'Create Response Request', type: :request do
       it 'creates a valid pdf file the data filled in correctly' do
         # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
         reference = json_response.dig(:meta, 'BuildResponse', :reference)
-        output_filename_pdf = "#{reference}_ET3_.pdf"
+        respondent_name = input_respondent_factory.name
+        output_filename_pdf = "#{reference}_ET3_#{formatted_name_for_filename(respondent_name)}.pdf"
         expect(staging_folder.et3_pdf_file(output_filename_pdf)).to have_correct_contents_for(
           response: input_response_factory,
           respondent: input_respondent_factory,
@@ -199,8 +206,8 @@ RSpec.describe 'Create Response Request', type: :request do
 
       it 'includes the rtf file in the staging folder' do
         reference = json_response.dig(:meta, 'BuildResponse', :reference)
-        company_name_underscored = input_respondent_factory.name.split(/\W/).join('_')
-        output_filename_rtf = "#{reference}_ET3_Attachment_#{company_name_underscored}.rtf"
+        respondent_name = input_respondent_factory.name
+        output_filename_rtf = "#{reference}_ET3_Attachment_#{respondent_name}.rtf"
         Dir.mktmpdir do |dir|
           full_path = File.join(dir, output_filename_rtf)
           staging_folder.extract(output_filename_rtf, to: full_path)

--- a/spec/requests/create_response_spec.rb
+++ b/spec/requests/create_response_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Create Response Request', type: :request do
       end
 
       def formatted_name_for_filename(text)
-        text.split(/\W/).join('_')
+        text.parameterize(separator: '_', preserve_case: true)
       end
 
       let(:staging_folder) do

--- a/spec/services/export_service_spec.rb
+++ b/spec/services/export_service_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ExportService do
 
       # Assert
       expected_filenames = responses.map do |r|
-        company_name_underscored = r.respondent.name.split(/\W/).join('_')
+        company_name_underscored = r.respondent.name.parameterize(separator: '_', preserve_case: true)
         "#{r.reference}_ET3_#{company_name_underscored}.txt"
       end
       expect(EtApi::Test::StoredZipFile.file_names(zip: ExportedFile.last)).to include(*expected_filenames)
@@ -96,7 +96,7 @@ RSpec.describe ExportService do
 
       # Assert
       expected_filenames = responses.map do |r|
-        company_name_underscored = r.respondent.name.split(/\W/).join('_')
+        company_name_underscored = r.respondent.name.parameterize(separator: '_', preserve_case: true)
         "#{r.reference}_ET3_Attachment_#{company_name_underscored}.rtf"
       end
       expect(EtApi::Test::StoredZipFile.file_names(zip: ExportedFile.last)).to include(*expected_filenames)

--- a/spec/services/export_service_spec.rb
+++ b/spec/services/export_service_spec.rb
@@ -83,7 +83,10 @@ RSpec.describe ExportService do
       service.export
 
       # Assert
-      expected_filenames = responses.map { |c| "#{c.reference}_ET3_.txt" }
+      expected_filenames = responses.map do |r|
+        company_name_underscored = r.respondent.name.split(/\W/).join('_')
+        "#{r.reference}_ET3_#{company_name_underscored}.txt"
+      end
       expect(EtApi::Test::StoredZipFile.file_names(zip: ExportedFile.last)).to include(*expected_filenames)
     end
 


### PR DESCRIPTION
The ET3 ETHOS filenames now contain the underscored respondent name (company name)