### PR TITLE
Response mailer now uses email_receipt field from api for the to address

### DIFF
--- a/app/event_handlers/response_created_handler.rb
+++ b/app/event_handlers/response_created_handler.rb
@@ -3,7 +3,7 @@ class ResponseCreatedHandler
     ResponseFileBuilderService.new(response).call
     ResponseExportService.new(response).to_be_exported
     response.save
-    send_email(response) if response.try(:respondent).try(:email_address).present?
+    send_email(response) if response.email_receipt.present?
   end
 
   private

--- a/app/mailers/response_mailer.rb
+++ b/app/mailers/response_mailer.rb
@@ -3,7 +3,7 @@ class ResponseMailer < ApplicationMailer
     @response = params[:response]
     @office = params[:office]
     attachments.inline["#{@response.reference}.pdf"] = @response.pdf_file.file.download
-    mail to: @response.respondent.email_address,
+    mail to: @response.email_receipt,
          subject: 'Your Response to Employment Tribunal claim online form receipt',
          template_path: 'mailers/response_mailer'
   end

--- a/spec/support/email_support/email_objects/new_response_email_html.rb
+++ b/spec/support/email_support/email_objects/new_response_email_html.rb
@@ -46,6 +46,10 @@ module EtApi
           mail.subject == 'Your Response to Employment Tribunal claim online form receipt'
         end
 
+        def has_correct_to_address_for?(input_data) # rubocop:disable Naming/PredicateName
+          mail.to.include?(input_data.email_receipt)
+        end
+
         def office_name
           re = /It has been forwarded to the (.*) office/
           office_name_element.text.match(re)[1]
@@ -56,6 +60,7 @@ module EtApi
           aggregate_failures 'validating content' do
             expect(self.reference).to eql reference
             expect(has_correct_subject?).to be true
+            expect(has_correct_to_address_for?(input_data)).to be true
             expect(office_name).to eql office.name
             expect(office_address).to eql office.address
             expect(office_telephone).to eql office.telephone

--- a/spec/support/email_support/email_objects/new_response_email_text.rb
+++ b/spec/support/email_support/email_objects/new_response_email_text.rb
@@ -41,6 +41,10 @@ module EtApi
           mail.subject == 'Your Response to Employment Tribunal claim online form receipt'
         end
 
+        def has_correct_to_address_for?(input_data) # rubocop:disable Naming/PredicateName
+          mail.to.include?(input_data.email_receipt)
+        end
+
         def office_name
           re = /It has been forwarded to the (.*) office/
           office_name_line.match(re)[1]
@@ -51,6 +55,7 @@ module EtApi
           aggregate_failures 'validating content' do
             expect(self.reference).to eql reference
             expect(has_correct_subject?).to be true
+            expect(has_correct_to_address_for?(input_data)).to be true
             expect(office_name).to eql office.name
             expect(office_address).to eql office.address
             expect(office_telephone).to eql office.telephone


### PR DESCRIPTION
Response mailer now uses email_receipt field from api for the to address