### PR TITLE
Upgraded sprockets to 3.7.2 due to CVE-2018-3760 security issue. 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,7 +287,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
Upgraded sprockets to 3.7.2 due to CVE-2018-3760 security issue. Whilst this does not affect our application (as we are not hosting any assets here), it stops github showing a concern about a security issue.