### PR TITLE
Claim and response exporter can accept names with non alpha characters

### DIFF
--- a/app/services/export_service_exporters/claim_exporter.rb
+++ b/app/services/export_service_exporters/claim_exporter.rb
@@ -36,7 +36,9 @@ module ExportServiceExporters
     def export_file(claim:, to:, prefix:, ext:, type:)
       stored_file = claim_export_service.new(claim).send(:"export_#{type}")
       claimant = claim.primary_claimant
-      fn = "#{claim.reference}_#{prefix}_#{claimant.first_name.tr(' ', '_')}_#{claimant.last_name}.#{ext}"
+      first = replacing_special claimant.first_name
+      last = replacing_special claimant.last_name
+      fn = "#{claim.reference}_#{prefix}_#{first}_#{last}.#{ext}"
       stored_file.download_blob_to File.join(to, fn)
     end
 
@@ -46,6 +48,10 @@ module ExportServiceExporters
 
     def claim_has_rtf?(claim:)
       claim.uploaded_files.any? { |f| f.filename.starts_with?('et1_attachment') && f.filename.ends_with?('.rtf') }
+    end
+
+    def replacing_special(text)
+      text.gsub(/\s/, '_').gsub(/\W/, '')
     end
 
     attr_accessor :claim_export_service, :claims_to_export, :exports

--- a/app/services/export_service_exporters/response_exporter.rb
+++ b/app/services/export_service_exporters/response_exporter.rb
@@ -33,7 +33,7 @@ module ExportServiceExporters
 
     def export_file(response:, to:, ext:, type:)
       stored_file = response_export_service.new(response).send(:"export_#{type}")
-      company_name_underscored = response.respondent.name.parameterize(separator: '_', preserve_case: true)
+      company_name_underscored = replacing_special response.respondent.name
       fn = "#{response.reference}_ET3_#{company_name_underscored}.#{ext}"
       stored_file.download_blob_to File.join(to, fn)
     end
@@ -41,9 +41,13 @@ module ExportServiceExporters
     def export_file_as_attachment(response:, to:, ext:, type:, optional: false)
       stored_file = response_export_service.new(response).send(:"export_#{type}")
       return if optional && stored_file.nil?
-      company_name_underscored = response.respondent.name.parameterize(separator: '_', preserve_case: true)
+      company_name_underscored = replacing_special response.respondent.name
       fn = "#{response.reference}_ET3_Attachment_#{company_name_underscored}.#{ext}"
       stored_file.download_blob_to File.join(to, fn)
+    end
+
+    def replacing_special(text)
+      text.gsub(/\s/, '_').gsub(/\W/, '')
     end
 
     attr_accessor :response_export_service, :responses_to_export, :exports

--- a/spec/factories/claimant_factory.rb
+++ b/spec/factories/claimant_factory.rb
@@ -201,5 +201,11 @@ FactoryBot.define do
       gender ''
       date_of_birth { Date.parse('04/10/1998') }
     end
+
+    trait :mr_na_o_malley do
+      darien_bahringer
+      first_name 'n/a'
+      last_name "O'Malley"
+    end
   end
 end

--- a/spec/factories/respondent_factory.rb
+++ b/spec/factories/respondent_factory.rb
@@ -34,5 +34,10 @@ FactoryBot.define do
       organisation_more_than_one_site true
       employment_at_site_number 5
     end
+
+    trait :mr_na_o_malley do
+      example_data
+      name "n/a O'Malley"
+    end
   end
 end

--- a/spec/factories/xml/xml_claim_factory.rb
+++ b/spec/factories/xml/xml_claim_factory.rb
@@ -211,6 +211,12 @@ FactoryBot.define do
 
     end
 
+    trait :mr_na_o_malley do
+      mr_first_last
+      forename 'n/a'
+      surname "O'Malley"
+    end
+
     trait :mr_first_last do
       group_contact 'true'
       title 'Mr'
@@ -438,6 +444,11 @@ FactoryBot.define do
     association :acas, :ac1234567890, factory: :xml_claim_acas
     association :alt_address, :piccadilly_circus_110, factory: :xml_claim_address
     alt_phone_number '03333 423554'
+
+    trait :mr_na_o_leary do
+      respondent_name
+      name "n/a O'Leary"
+    end
 
     trait :respondent_name do
       group_contact 'true'

--- a/spec/services/export_service_exporters/claim_exporter_spec.rb
+++ b/spec/services/export_service_exporters/claim_exporter_spec.rb
@@ -15,21 +15,21 @@ RSpec.describe ExportServiceExporters::ClaimExporter do
       it 'exports a pdf file with the correct name' do
         Dir.mktmpdir do |dir|
           exporter.export(to: dir)
-          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_omalley.pdf"))).to be true
+          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_OMalley.pdf"))).to be true
         end
       end
 
       it 'exports a txt file with the correct name' do
         Dir.mktmpdir do |dir|
           exporter.export(to: dir)
-          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_omalley.txt"))).to be true
+          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_OMalley.txt"))).to be true
         end
       end
 
       it 'exports an xml file with the correct name' do
         Dir.mktmpdir do |dir|
           exporter.export(to: dir)
-          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_omalley.xml"))).to be true
+          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_OMalley.xml"))).to be true
         end
       end
     end

--- a/spec/services/export_service_exporters/claim_exporter_spec.rb
+++ b/spec/services/export_service_exporters/claim_exporter_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+RSpec.describe ExportServiceExporters::ClaimExporter do
+  describe '#export' do
+    context 'with claim that has claimant with non alpha numerics in name' do
+      subject(:exporter) { described_class.new }
+
+      let(:claimants) { build_list(:claimant, 1, :mr_na_o_malley) }
+      let(:claim) { build(:claim, :with_pdf_file, :with_xml_file, :with_text_file, number_of_claimants: 0, claimants: claimants) }
+
+      # Create an export record to allow the claim to be found
+      before do
+        Export.create resource: claim
+      end
+
+      it 'exports a pdf file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_omalley.pdf"))).to be true
+        end
+      end
+
+      it 'exports a txt file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_omalley.txt"))).to be true
+        end
+      end
+
+      it 'exports an xml file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_omalley.xml"))).to be true
+        end
+      end
+    end
+  end
+end

--- a/spec/services/export_service_exporters/response_exporter_spec.rb
+++ b/spec/services/export_service_exporters/response_exporter_spec.rb
@@ -15,21 +15,21 @@ RSpec.describe ExportServiceExporters::ResponseExporter do
       it 'exports a pdf file with the correct name' do
         Dir.mktmpdir do |dir|
           exporter.export(to: dir)
-          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_na_omalley.pdf"))).to be true
+          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_na_OMalley.pdf"))).to be true
         end
       end
 
       it 'exports a txt file with the correct name' do
         Dir.mktmpdir do |dir|
           exporter.export(to: dir)
-          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_na_omalley.txt"))).to be true
+          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_na_OMalley.txt"))).to be true
         end
       end
 
       it 'exports an xml file with the correct name' do
         Dir.mktmpdir do |dir|
           exporter.export(to: dir)
-          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_Attachment_na_omalley.rtf"))).to be true
+          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_Attachment_na_OMalley.rtf"))).to be true
         end
       end
     end

--- a/spec/services/export_service_exporters/response_exporter_spec.rb
+++ b/spec/services/export_service_exporters/response_exporter_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+RSpec.describe ExportServiceExporters::ResponseExporter do
+  describe '#export' do
+    context 'with response that has claimant with non alpha numerics in name' do
+      subject(:exporter) { described_class.new }
+
+      let(:respondent) { build(:respondent, :mr_na_o_malley) }
+      let(:response) { build(:response, :with_pdf_file, :with_text_file, :with_rtf_file, respondent: respondent) }
+
+      # Create an export record to allow the claim to be found
+      before do
+        Export.create resource: response
+      end
+
+      it 'exports a pdf file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_na_omalley.pdf"))).to be true
+        end
+      end
+
+      it 'exports a txt file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_na_omalley.txt"))).to be true
+        end
+      end
+
+      it 'exports an xml file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_Attachment_na_omalley.rtf"))).to be true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the issues seen in production yesterday where strange characters in the persons name were coming through to the filename and causing files not to be found.
Now, anything that is classed as white space is converted to an underscore and any other non word characters are removed completely from the filename.