### PR TITLE
Skip over errors during export

### DIFF
--- a/spec/services/export_service_exporters/response_exporter_spec.rb
+++ b/spec/services/export_service_exporters/response_exporter_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 RSpec.describe ExportServiceExporters::ResponseExporter do
   describe '#export' do
-    context 'with response that has claimant with non alpha numerics in name' do
+    context 'with response that has respondent with non alpha numerics in name' do
       subject(:exporter) { described_class.new }
 
       let(:respondent) { build(:respondent, :mr_na_o_malley) }
       let(:response) { build(:response, :with_pdf_file, :with_text_file, :with_rtf_file, respondent: respondent) }
 
-      # Create an export record to allow the claim to be found
+      # Create an export record to allow the response to be found
       before do
         Export.create resource: response
       end
@@ -30,6 +30,76 @@ RSpec.describe ExportServiceExporters::ResponseExporter do
         Dir.mktmpdir do |dir|
           exporter.export(to: dir)
           expect(File.exist?(File.join(dir, "#{response.reference}_ET3_Attachment_na_OMalley.rtf"))).to be true
+        end
+      end
+    end
+
+    context 'with an error injected when second response out of 3 is processed' do
+      subject(:exporter) { described_class.new response_export_service: response_export_service_class }
+
+      let(:respondent) { build(:respondent) }
+      let(:response_export_service_class) { class_double ResponseExportService }
+      let(:response_export_service1) { ResponseExportService.new(responses[0]) }
+      let(:response_export_service2) { ResponseExportService.new(responses[1]) }
+      let(:response_export_service3) { ResponseExportService.new(responses[2]) }
+      let(:responses) { create_list(:response, 3, :ready_for_export, :with_pdf_file, :with_text_file, :with_rtf_file, respondent: respondent) }
+
+      # This is just one way of forcing an error.  Each iteration uses the response export service's :export_txt method
+      # so we force that to raise an error
+      before do
+        allow(response_export_service_class).to receive(:new).with(responses[0]).and_return response_export_service1
+        allow(response_export_service_class).to receive(:new).with(responses[1]).and_return response_export_service2
+        allow(response_export_service_class).to receive(:new).with(responses[2]).and_return response_export_service3
+        allow(response_export_service2).to receive(:export_txt).and_raise(StandardError)
+      end
+
+      it 'exports a pdf for the first and last response' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          aggregate_failures 'Validating pdfs do exist for 2 responses and not for the other' do
+            expect(Dir.glob(File.join(dir, "#{responses[0].reference}_ET3_*.pdf"))).to be_present
+            expect(Dir.glob(File.join(dir, "#{responses[1].reference}_ET3_*.pdf"))).to be_empty
+            expect(Dir.glob(File.join(dir, "#{responses[2].reference}_ET3_*.pdf"))).to be_present
+          end
+        end
+      end
+    end
+
+    context 'with an error injected when second and fourth response out of 5 is processed' do
+      subject(:exporter) { described_class.new response_export_service: response_export_service_class }
+
+      let(:respondent) { build(:respondent) }
+      let(:response_export_service_class) { class_double ResponseExportService }
+      let(:response_export_service1) { ResponseExportService.new(responses[0]) }
+      let(:response_export_service2) { ResponseExportService.new(responses[1]) }
+      let(:response_export_service3) { ResponseExportService.new(responses[2]) }
+      let(:response_export_service4) { ResponseExportService.new(responses[3]) }
+      let(:response_export_service5) { ResponseExportService.new(responses[4]) }
+      let(:responses) { create_list(:response, 5, :ready_for_export, :with_pdf_file, :with_text_file, :with_rtf_file, respondent: respondent) }
+
+      # This is just one way of forcing an error.  Each iteration uses the response export service's :export_pdf and :export_txt methods
+      # so we force one of each of those to raise an error.  This will prove that no stray files are left behind if the
+      # code exits from different points.
+      before do
+        allow(response_export_service_class).to receive(:new).with(responses[0]).and_return response_export_service1
+        allow(response_export_service_class).to receive(:new).with(responses[1]).and_return response_export_service2
+        allow(response_export_service_class).to receive(:new).with(responses[2]).and_return response_export_service3
+        allow(response_export_service_class).to receive(:new).with(responses[3]).and_return response_export_service4
+        allow(response_export_service_class).to receive(:new).with(responses[4]).and_return response_export_service5
+        allow(response_export_service2).to receive(:export_txt).and_raise(StandardError)
+        allow(response_export_service4).to receive(:export_pdf).and_raise(StandardError)
+      end
+
+      it 'exports a pdf for the first, third and last response' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          aggregate_failures 'Verifying presence of all response pdf files' do
+            expect(Dir.glob(File.join(dir, "#{responses[0].reference}_ET3_*.pdf"))).to be_present
+            expect(Dir.glob(File.join(dir, "#{responses[1].reference}_ET3_*.pdf"))).to be_empty
+            expect(Dir.glob(File.join(dir, "#{responses[2].reference}_ET3_*.pdf"))).to be_present
+            expect(Dir.glob(File.join(dir, "#{responses[3].reference}_ET3_*.pdf"))).to be_empty
+            expect(Dir.glob(File.join(dir, "#{responses[4].reference}_ET3_*.pdf"))).to be_present
+          end
         end
       end
     end


### PR DESCRIPTION
This PR prevents any errors during export from blocking the queue.
So, if you had 10 claims to be exported and the 5th one error'd for whatever reason - the other 9 would go through and the 5th left unprocessed (any files already generated up to the point of the error would be discarded and not included in the final zip file).

Then, the next time the cron job ran - the 5th one will still be in there and the system will try again - logging errors until the problem is fixed.  There is no mechanism to 'give up'