### PR TITLE
Fix for duplicate underscore issue in filenames for claims and responses

### DIFF
--- a/app/services/export_service_exporters/claim_exporter.rb
+++ b/app/services/export_service_exporters/claim_exporter.rb
@@ -57,7 +57,7 @@ module ExportServiceExporters
     end
 
     def replacing_special(text)
-      text.gsub(/\s/, '_').gsub(/\W/, '')
+      text.gsub(/\W/, '').parameterize(separator: '_', preserve_case: true)
     end
 
     def with_exception_logging

--- a/app/services/export_service_exporters/response_exporter.rb
+++ b/app/services/export_service_exporters/response_exporter.rb
@@ -53,7 +53,7 @@ module ExportServiceExporters
     end
 
     def replacing_special(text)
-      text.gsub(/\s/, '_').gsub(/\W/, '')
+      text.gsub(/\s/, '_').gsub(/\W/, '').parameterize(separator: '_', preserve_case: true)
     end
 
     def with_exception_logging

--- a/spec/services/export_service_exporters/claim_exporter_spec.rb
+++ b/spec/services/export_service_exporters/claim_exporter_spec.rb
@@ -34,6 +34,39 @@ RSpec.describe ExportServiceExporters::ClaimExporter do
       end
     end
 
+    context 'with claim that has claimant with non alpha numerics in name and an underscore' do
+      subject(:exporter) { described_class.new }
+
+      let(:claimants) { build_list(:claimant, 1, :mr_na_o_malley, last_name: "_O'Malley") }
+      let(:claim) { build(:claim, :with_pdf_file, :with_xml_file, :with_text_file, number_of_claimants: 0, claimants: claimants) }
+
+      # Create an export record to allow the claim to be found
+      before do
+        Export.create resource: claim
+      end
+
+      it 'exports a pdf file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_OMalley.pdf"))).to be true
+        end
+      end
+
+      it 'exports a txt file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_OMalley.txt"))).to be true
+        end
+      end
+
+      it 'exports an xml file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{claim.reference}_ET1_na_OMalley.xml"))).to be true
+        end
+      end
+    end
+
     context 'with an error injected when second claim out of 3 is processed' do
       subject(:exporter) { described_class.new claim_export_service: claim_export_service_class }
 

--- a/spec/services/export_service_exporters/response_exporter_spec.rb
+++ b/spec/services/export_service_exporters/response_exporter_spec.rb
@@ -34,6 +34,39 @@ RSpec.describe ExportServiceExporters::ResponseExporter do
       end
     end
 
+    context 'with response that has claimant with non alpha numerics in name and an underscore' do
+      subject(:exporter) { described_class.new }
+
+      let(:respondent) { build(:respondent, :mr_na_o_malley, name: "n/a _O'Malley") }
+      let(:response) { build(:response, :with_pdf_file, :with_text_file, :with_rtf_file, respondent: respondent) }
+
+      # Create an export record to allow the claim to be found
+      before do
+        Export.create resource: response
+      end
+
+      it 'exports a pdf file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_na_OMalley.pdf"))).to be true
+        end
+      end
+
+      it 'exports a txt file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_na_OMalley.txt"))).to be true
+        end
+      end
+
+      it 'exports an xml file with the correct name' do
+        Dir.mktmpdir do |dir|
+          exporter.export(to: dir)
+          expect(File.exist?(File.join(dir, "#{response.reference}_ET3_Attachment_na_OMalley.rtf"))).to be true
+        end
+      end
+    end
+
     context 'with an error injected when second response out of 3 is processed' do
       subject(:exporter) { described_class.new response_export_service: response_export_service_class }
 


### PR DESCRIPTION
Fix for duplicate underscore issue in filenames for claim and response exporter