### PR TITLE
Fixed RST-1343 Occasional incorrect naming of txt files for ET1

### DIFF
--- a/app/models/claim_claimant.rb
+++ b/app/models/claim_claimant.rb
@@ -5,4 +5,19 @@
 class ClaimClaimant < ApplicationRecord
   belongs_to :claim
   belongs_to :claimant
+
+  accepts_nested_attributes_for :claimant
+
+  def self.primary_claimant
+    where(primary: true).first.try(:claimant)
+  end
+
+  def self.secondary_claimants
+    primary = primary_claimant
+    if primary
+      where('claimant_id != ?', primary.id)
+    else
+      self
+    end
+  end
 end

--- a/app/services/claim_file_builder/build_claim_text_file.rb
+++ b/app/services/claim_file_builder/build_claim_text_file.rb
@@ -16,7 +16,7 @@ module ClaimFileBuilder
 
     def self.render(claim)
       ApplicationController.render "file_builders/export.txt.erb", locals: {
-        claim: claim, primary_claimant: claim.claimants.first,
+        claim: claim, primary_claimant: claim.primary_claimant,
         primary_respondent: claim.respondents.first,
         primary_representative: claim.representatives.first,
         additional_respondents: claim.respondents[1..-1]

--- a/app/services/claim_file_builder/build_claimants_text_file.rb
+++ b/app/services/claim_file_builder/build_claimants_text_file.rb
@@ -16,8 +16,8 @@ module ClaimFileBuilder
 
     def self.render(claim)
       ApplicationController.render "file_builders/export_claimants.txt.erb", locals: {
-        claim: claim, primary_claimant: claim.claimants.first,
-        secondary_claimants: claim.claimants[1..-1],
+        claim: claim, primary_claimant: claim.primary_claimant,
+        secondary_claimants: claim.secondary_claimants,
         primary_respondent: claim.respondents.first
       }
     end

--- a/app/services/claim_file_builder/claim_filename.rb
+++ b/app/services/claim_file_builder/claim_filename.rb
@@ -4,7 +4,7 @@ module ClaimFileBuilder
 
     class_methods do
       def filename_for(claim:, extension: "txt", prefix: "et1")
-        claimant = claim.claimants.first
+        claimant = claim.primary_claimant
         "#{prefix}_#{claimant.first_name.tr(' ', '_')}_#{claimant.last_name}.#{extension}"
       end
     end

--- a/app/services/claim_file_builder_service.rb
+++ b/app/services/claim_file_builder_service.rb
@@ -15,7 +15,7 @@ class ClaimFileBuilderService
 
   def call
     add_file :claim_text_file, to: claim
-    add_file :claimants_text_file, to: claim if claim.claimants.length > 1
+    add_file :claimants_text_file, to: claim if claim.multiple_claimants?
   end
 
   private

--- a/app/services/claim_xml_import_service.rb
+++ b/app/services/claim_xml_import_service.rb
@@ -71,16 +71,20 @@ class ClaimXmlImportService # rubocop:disable Metrics/ClassLength
 
   def converted_associated_data
     {
-      claimants_attributes: converted_claimants_data,
+      claim_claimants_attributes: converted_claim_claimants_data,
       respondents_attributes: converted_respondents_data,
       representatives_attributes: converted_representatives_data,
       uploaded_files_attributes: converted_files_data
     }
   end
 
-  def converted_claimants_data
+  def converted_claim_claimants_data
     collection(root, 'Claimants').map do |claimant|
-      convert_claimant_data(claimant)
+      {
+        primary: claimant['GroupContact'] == 'true',
+        claimant_attributes: convert_claimant_data(claimant)
+      }
+
     end
   end
 

--- a/app/services/export_service_exporters/claim_exporter.rb
+++ b/app/services/export_service_exporters/claim_exporter.rb
@@ -33,7 +33,7 @@ module ExportServiceExporters
     def export_files(claim, to:)
       export_file(claim: claim, to: to, prefix: 'ET1', ext: :pdf, type: :pdf)
       export_file(claim: claim, to: to, prefix: 'ET1', ext: :txt, type: :txt)
-      export_file(claim: claim, to: to, prefix: 'ET1a', ext: :txt, type: :claimants_txt) if claim.claimants.count > 1
+      export_file(claim: claim, to: to, prefix: 'ET1a', ext: :txt, type: :claimants_txt) if claim.claimant_count > 1
       export_file(claim: claim, to: to, prefix: 'ET1a', ext: :csv, type: :claimants_csv) if claim_has_csv?(claim: claim)
       export_file(claim: claim, to: to, prefix: 'ET1_Attachment', ext: :rtf, type: :rtf) if claim_has_rtf?(claim: claim)
     end

--- a/app/views/file_builders/export.txt.erb
+++ b/app/views/file_builders/export.txt.erb
@@ -76,7 +76,7 @@ Representative's E-mail address: <%= rep.try(:email_address) %>
 
 ## Section 10: Multiple cases
 
-~10.2 ET1a Submitted: <%= claim.claimants.length > 1 ? 'Yes' : '' %>
+~10.2 ET1a Submitted: <%= claim.multiple_claimants? ? 'Yes' : '' %>
 
 ## Section 11: Details of Additional Respondents
 

--- a/db/migrate/20180828120205_add_primary_to_claim_claimants.rb
+++ b/db/migrate/20180828120205_add_primary_to_claim_claimants.rb
@@ -1,0 +1,5 @@
+class AddPrimaryToClaimClaimants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :claim_claimants, :primary, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,9 +1,7 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
-SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -22,6 +20,8 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
+SET search_path = public, pg_catalog;
+
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -30,7 +30,7 @@ SET default_with_oids = false;
 -- Name: active_admin_comments; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.active_admin_comments (
+CREATE TABLE active_admin_comments (
     id bigint NOT NULL,
     namespace character varying,
     body text,
@@ -47,7 +47,7 @@ CREATE TABLE public.active_admin_comments (
 -- Name: active_admin_comments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.active_admin_comments_id_seq
+CREATE SEQUENCE active_admin_comments_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -59,14 +59,14 @@ CREATE SEQUENCE public.active_admin_comments_id_seq
 -- Name: active_admin_comments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.active_admin_comments_id_seq OWNED BY public.active_admin_comments.id;
+ALTER SEQUENCE active_admin_comments_id_seq OWNED BY active_admin_comments.id;
 
 
 --
 -- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.active_storage_attachments (
+CREATE TABLE active_storage_attachments (
     id bigint NOT NULL,
     name character varying NOT NULL,
     record_type character varying NOT NULL,
@@ -80,7 +80,7 @@ CREATE TABLE public.active_storage_attachments (
 -- Name: active_storage_attachments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.active_storage_attachments_id_seq
+CREATE SEQUENCE active_storage_attachments_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -92,14 +92,14 @@ CREATE SEQUENCE public.active_storage_attachments_id_seq
 -- Name: active_storage_attachments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.active_storage_attachments_id_seq OWNED BY public.active_storage_attachments.id;
+ALTER SEQUENCE active_storage_attachments_id_seq OWNED BY active_storage_attachments.id;
 
 
 --
 -- Name: active_storage_blobs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.active_storage_blobs (
+CREATE TABLE active_storage_blobs (
     id bigint NOT NULL,
     key character varying NOT NULL,
     filename character varying NOT NULL,
@@ -115,7 +115,7 @@ CREATE TABLE public.active_storage_blobs (
 -- Name: active_storage_blobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.active_storage_blobs_id_seq
+CREATE SEQUENCE active_storage_blobs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -127,14 +127,14 @@ CREATE SEQUENCE public.active_storage_blobs_id_seq
 -- Name: active_storage_blobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.active_storage_blobs_id_seq OWNED BY public.active_storage_blobs.id;
+ALTER SEQUENCE active_storage_blobs_id_seq OWNED BY active_storage_blobs.id;
 
 
 --
 -- Name: addresses; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.addresses (
+CREATE TABLE addresses (
     id bigint NOT NULL,
     building character varying,
     street character varying,
@@ -151,7 +151,7 @@ CREATE TABLE public.addresses (
 -- Name: addresses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.addresses_id_seq
+CREATE SEQUENCE addresses_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -163,14 +163,14 @@ CREATE SEQUENCE public.addresses_id_seq
 -- Name: addresses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.addresses_id_seq OWNED BY public.addresses.id;
+ALTER SEQUENCE addresses_id_seq OWNED BY addresses.id;
 
 
 --
 -- Name: admin_permissions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.admin_permissions (
+CREATE TABLE admin_permissions (
     id bigint NOT NULL,
     name character varying,
     created_at timestamp without time zone NOT NULL,
@@ -182,7 +182,7 @@ CREATE TABLE public.admin_permissions (
 -- Name: admin_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.admin_permissions_id_seq
+CREATE SEQUENCE admin_permissions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -194,14 +194,14 @@ CREATE SEQUENCE public.admin_permissions_id_seq
 -- Name: admin_permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.admin_permissions_id_seq OWNED BY public.admin_permissions.id;
+ALTER SEQUENCE admin_permissions_id_seq OWNED BY admin_permissions.id;
 
 
 --
 -- Name: admin_role_permissions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.admin_role_permissions (
+CREATE TABLE admin_role_permissions (
     id bigint NOT NULL,
     role_id bigint,
     permission_id bigint
@@ -212,7 +212,7 @@ CREATE TABLE public.admin_role_permissions (
 -- Name: admin_role_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.admin_role_permissions_id_seq
+CREATE SEQUENCE admin_role_permissions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -224,14 +224,14 @@ CREATE SEQUENCE public.admin_role_permissions_id_seq
 -- Name: admin_role_permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.admin_role_permissions_id_seq OWNED BY public.admin_role_permissions.id;
+ALTER SEQUENCE admin_role_permissions_id_seq OWNED BY admin_role_permissions.id;
 
 
 --
 -- Name: admin_roles; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.admin_roles (
+CREATE TABLE admin_roles (
     id bigint NOT NULL,
     name character varying NOT NULL,
     is_admin boolean DEFAULT false,
@@ -243,7 +243,7 @@ CREATE TABLE public.admin_roles (
 -- Name: admin_roles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.admin_roles_id_seq
+CREATE SEQUENCE admin_roles_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -255,14 +255,14 @@ CREATE SEQUENCE public.admin_roles_id_seq
 -- Name: admin_roles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.admin_roles_id_seq OWNED BY public.admin_roles.id;
+ALTER SEQUENCE admin_roles_id_seq OWNED BY admin_roles.id;
 
 
 --
 -- Name: admin_user_roles; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.admin_user_roles (
+CREATE TABLE admin_user_roles (
     id bigint NOT NULL,
     user_id bigint,
     role_id bigint
@@ -273,7 +273,7 @@ CREATE TABLE public.admin_user_roles (
 -- Name: admin_user_roles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.admin_user_roles_id_seq
+CREATE SEQUENCE admin_user_roles_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -285,14 +285,14 @@ CREATE SEQUENCE public.admin_user_roles_id_seq
 -- Name: admin_user_roles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.admin_user_roles_id_seq OWNED BY public.admin_user_roles.id;
+ALTER SEQUENCE admin_user_roles_id_seq OWNED BY admin_user_roles.id;
 
 
 --
 -- Name: admin_users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.admin_users (
+CREATE TABLE admin_users (
     id bigint NOT NULL,
     email character varying DEFAULT ''::character varying NOT NULL,
     encrypted_password character varying DEFAULT ''::character varying NOT NULL,
@@ -321,7 +321,7 @@ CREATE TABLE public.admin_users (
 -- Name: admin_users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.admin_users_id_seq
+CREATE SEQUENCE admin_users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -333,14 +333,14 @@ CREATE SEQUENCE public.admin_users_id_seq
 -- Name: admin_users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.admin_users_id_seq OWNED BY public.admin_users.id;
+ALTER SEQUENCE admin_users_id_seq OWNED BY admin_users.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.ar_internal_metadata (
+CREATE TABLE ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -352,10 +352,11 @@ CREATE TABLE public.ar_internal_metadata (
 -- Name: claim_claimants; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.claim_claimants (
+CREATE TABLE claim_claimants (
     id bigint NOT NULL,
     claim_id bigint,
-    claimant_id bigint
+    claimant_id bigint,
+    "primary" boolean DEFAULT false
 );
 
 
@@ -363,7 +364,7 @@ CREATE TABLE public.claim_claimants (
 -- Name: claim_claimants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.claim_claimants_id_seq
+CREATE SEQUENCE claim_claimants_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -375,14 +376,14 @@ CREATE SEQUENCE public.claim_claimants_id_seq
 -- Name: claim_claimants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.claim_claimants_id_seq OWNED BY public.claim_claimants.id;
+ALTER SEQUENCE claim_claimants_id_seq OWNED BY claim_claimants.id;
 
 
 --
 -- Name: claim_representatives; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.claim_representatives (
+CREATE TABLE claim_representatives (
     id bigint NOT NULL,
     claim_id bigint,
     representative_id bigint,
@@ -395,7 +396,7 @@ CREATE TABLE public.claim_representatives (
 -- Name: claim_representatives_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.claim_representatives_id_seq
+CREATE SEQUENCE claim_representatives_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -407,14 +408,14 @@ CREATE SEQUENCE public.claim_representatives_id_seq
 -- Name: claim_representatives_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.claim_representatives_id_seq OWNED BY public.claim_representatives.id;
+ALTER SEQUENCE claim_representatives_id_seq OWNED BY claim_representatives.id;
 
 
 --
 -- Name: claim_respondents; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.claim_respondents (
+CREATE TABLE claim_respondents (
     id bigint NOT NULL,
     claim_id bigint,
     respondent_id bigint,
@@ -427,7 +428,7 @@ CREATE TABLE public.claim_respondents (
 -- Name: claim_respondents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.claim_respondents_id_seq
+CREATE SEQUENCE claim_respondents_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -439,14 +440,14 @@ CREATE SEQUENCE public.claim_respondents_id_seq
 -- Name: claim_respondents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.claim_respondents_id_seq OWNED BY public.claim_respondents.id;
+ALTER SEQUENCE claim_respondents_id_seq OWNED BY claim_respondents.id;
 
 
 --
 -- Name: claim_uploaded_files; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.claim_uploaded_files (
+CREATE TABLE claim_uploaded_files (
     id bigint NOT NULL,
     claim_id bigint,
     uploaded_file_id bigint,
@@ -459,7 +460,7 @@ CREATE TABLE public.claim_uploaded_files (
 -- Name: claim_uploaded_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.claim_uploaded_files_id_seq
+CREATE SEQUENCE claim_uploaded_files_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -471,14 +472,14 @@ CREATE SEQUENCE public.claim_uploaded_files_id_seq
 -- Name: claim_uploaded_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.claim_uploaded_files_id_seq OWNED BY public.claim_uploaded_files.id;
+ALTER SEQUENCE claim_uploaded_files_id_seq OWNED BY claim_uploaded_files.id;
 
 
 --
 -- Name: claimants; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.claimants (
+CREATE TABLE claimants (
     id bigint NOT NULL,
     title character varying,
     first_name character varying,
@@ -499,7 +500,7 @@ CREATE TABLE public.claimants (
 -- Name: claimants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.claimants_id_seq
+CREATE SEQUENCE claimants_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -511,14 +512,14 @@ CREATE SEQUENCE public.claimants_id_seq
 -- Name: claimants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.claimants_id_seq OWNED BY public.claimants.id;
+ALTER SEQUENCE claimants_id_seq OWNED BY claimants.id;
 
 
 --
 -- Name: claims; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.claims (
+CREATE TABLE claims (
     id bigint NOT NULL,
     reference character varying,
     submission_reference character varying,
@@ -538,7 +539,7 @@ CREATE TABLE public.claims (
 -- Name: claims_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.claims_id_seq
+CREATE SEQUENCE claims_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -550,14 +551,14 @@ CREATE SEQUENCE public.claims_id_seq
 -- Name: claims_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.claims_id_seq OWNED BY public.claims.id;
+ALTER SEQUENCE claims_id_seq OWNED BY claims.id;
 
 
 --
 -- Name: et_acas_api_download_logs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.et_acas_api_download_logs (
+CREATE TABLE et_acas_api_download_logs (
     id bigint NOT NULL,
     user_id character varying,
     certificate_number character varying,
@@ -573,7 +574,7 @@ CREATE TABLE public.et_acas_api_download_logs (
 -- Name: et_acas_api_download_logs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.et_acas_api_download_logs_id_seq
+CREATE SEQUENCE et_acas_api_download_logs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -585,14 +586,14 @@ CREATE SEQUENCE public.et_acas_api_download_logs_id_seq
 -- Name: et_acas_api_download_logs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.et_acas_api_download_logs_id_seq OWNED BY public.et_acas_api_download_logs.id;
+ALTER SEQUENCE et_acas_api_download_logs_id_seq OWNED BY et_acas_api_download_logs.id;
 
 
 --
 -- Name: exported_files; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.exported_files (
+CREATE TABLE exported_files (
     id bigint NOT NULL,
     filename character varying,
     content_type character varying,
@@ -605,7 +606,7 @@ CREATE TABLE public.exported_files (
 -- Name: exported_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.exported_files_id_seq
+CREATE SEQUENCE exported_files_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -617,14 +618,14 @@ CREATE SEQUENCE public.exported_files_id_seq
 -- Name: exported_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.exported_files_id_seq OWNED BY public.exported_files.id;
+ALTER SEQUENCE exported_files_id_seq OWNED BY exported_files.id;
 
 
 --
 -- Name: exports; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.exports (
+CREATE TABLE exports (
     id bigint NOT NULL,
     resource_id bigint,
     pdf_file_id bigint,
@@ -640,7 +641,7 @@ CREATE TABLE public.exports (
 -- Name: exports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.exports_id_seq
+CREATE SEQUENCE exports_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -652,14 +653,14 @@ CREATE SEQUENCE public.exports_id_seq
 -- Name: exports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.exports_id_seq OWNED BY public.exports.id;
+ALTER SEQUENCE exports_id_seq OWNED BY exports.id;
 
 
 --
 -- Name: office_post_codes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.office_post_codes (
+CREATE TABLE office_post_codes (
     id bigint NOT NULL,
     postcode character varying,
     office_id bigint,
@@ -672,7 +673,7 @@ CREATE TABLE public.office_post_codes (
 -- Name: office_post_codes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.office_post_codes_id_seq
+CREATE SEQUENCE office_post_codes_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -684,14 +685,14 @@ CREATE SEQUENCE public.office_post_codes_id_seq
 -- Name: office_post_codes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.office_post_codes_id_seq OWNED BY public.office_post_codes.id;
+ALTER SEQUENCE office_post_codes_id_seq OWNED BY office_post_codes.id;
 
 
 --
 -- Name: offices; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.offices (
+CREATE TABLE offices (
     id bigint NOT NULL,
     code integer,
     name character varying,
@@ -708,7 +709,7 @@ CREATE TABLE public.offices (
 -- Name: offices_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.offices_id_seq
+CREATE SEQUENCE offices_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -720,14 +721,14 @@ CREATE SEQUENCE public.offices_id_seq
 -- Name: offices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.offices_id_seq OWNED BY public.offices.id;
+ALTER SEQUENCE offices_id_seq OWNED BY offices.id;
 
 
 --
 -- Name: pre_allocated_file_keys; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.pre_allocated_file_keys (
+CREATE TABLE pre_allocated_file_keys (
     id bigint NOT NULL,
     key character varying,
     allocated_to_type character varying,
@@ -742,7 +743,7 @@ CREATE TABLE public.pre_allocated_file_keys (
 -- Name: pre_allocated_file_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.pre_allocated_file_keys_id_seq
+CREATE SEQUENCE pre_allocated_file_keys_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -754,14 +755,14 @@ CREATE SEQUENCE public.pre_allocated_file_keys_id_seq
 -- Name: pre_allocated_file_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.pre_allocated_file_keys_id_seq OWNED BY public.pre_allocated_file_keys.id;
+ALTER SEQUENCE pre_allocated_file_keys_id_seq OWNED BY pre_allocated_file_keys.id;
 
 
 --
 -- Name: representatives; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.representatives (
+CREATE TABLE representatives (
     id bigint NOT NULL,
     name character varying,
     organisation_name character varying,
@@ -785,7 +786,7 @@ CREATE TABLE public.representatives (
 -- Name: representatives_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.representatives_id_seq
+CREATE SEQUENCE representatives_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -797,14 +798,14 @@ CREATE SEQUENCE public.representatives_id_seq
 -- Name: representatives_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.representatives_id_seq OWNED BY public.representatives.id;
+ALTER SEQUENCE representatives_id_seq OWNED BY representatives.id;
 
 
 --
 -- Name: respondents; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.respondents (
+CREATE TABLE respondents (
     id bigint NOT NULL,
     name character varying,
     address_id bigint,
@@ -830,7 +831,7 @@ CREATE TABLE public.respondents (
 -- Name: respondents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.respondents_id_seq
+CREATE SEQUENCE respondents_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -842,14 +843,14 @@ CREATE SEQUENCE public.respondents_id_seq
 -- Name: respondents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.respondents_id_seq OWNED BY public.respondents.id;
+ALTER SEQUENCE respondents_id_seq OWNED BY respondents.id;
 
 
 --
 -- Name: response_uploaded_files; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.response_uploaded_files (
+CREATE TABLE response_uploaded_files (
     id bigint NOT NULL,
     response_id bigint,
     uploaded_file_id bigint,
@@ -862,7 +863,7 @@ CREATE TABLE public.response_uploaded_files (
 -- Name: response_uploaded_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.response_uploaded_files_id_seq
+CREATE SEQUENCE response_uploaded_files_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -874,14 +875,14 @@ CREATE SEQUENCE public.response_uploaded_files_id_seq
 -- Name: response_uploaded_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.response_uploaded_files_id_seq OWNED BY public.response_uploaded_files.id;
+ALTER SEQUENCE response_uploaded_files_id_seq OWNED BY response_uploaded_files.id;
 
 
 --
 -- Name: responses; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.responses (
+CREATE TABLE responses (
     id bigint NOT NULL,
     respondent_id bigint,
     representative_id bigint,
@@ -923,7 +924,7 @@ CREATE TABLE public.responses (
 -- Name: responses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.responses_id_seq
+CREATE SEQUENCE responses_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -935,14 +936,14 @@ CREATE SEQUENCE public.responses_id_seq
 -- Name: responses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.responses_id_seq OWNED BY public.responses.id;
+ALTER SEQUENCE responses_id_seq OWNED BY responses.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.schema_migrations (
+CREATE TABLE schema_migrations (
     version character varying NOT NULL
 );
 
@@ -951,7 +952,7 @@ CREATE TABLE public.schema_migrations (
 -- Name: unique_references; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.unique_references (
+CREATE TABLE unique_references (
     id bigint NOT NULL,
     number integer,
     created_at timestamp without time zone NOT NULL,
@@ -963,7 +964,7 @@ CREATE TABLE public.unique_references (
 -- Name: unique_references_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.unique_references_id_seq
+CREATE SEQUENCE unique_references_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -975,14 +976,14 @@ CREATE SEQUENCE public.unique_references_id_seq
 -- Name: unique_references_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.unique_references_id_seq OWNED BY public.unique_references.id;
+ALTER SEQUENCE unique_references_id_seq OWNED BY unique_references.id;
 
 
 --
 -- Name: uploaded_files; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.uploaded_files (
+CREATE TABLE uploaded_files (
     id bigint NOT NULL,
     filename character varying,
     checksum character varying,
@@ -995,7 +996,7 @@ CREATE TABLE public.uploaded_files (
 -- Name: uploaded_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.uploaded_files_id_seq
+CREATE SEQUENCE uploaded_files_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1007,427 +1008,427 @@ CREATE SEQUENCE public.uploaded_files_id_seq
 -- Name: uploaded_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.uploaded_files_id_seq OWNED BY public.uploaded_files.id;
+ALTER SEQUENCE uploaded_files_id_seq OWNED BY uploaded_files.id;
 
 
 --
--- Name: active_admin_comments id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.active_admin_comments ALTER COLUMN id SET DEFAULT nextval('public.active_admin_comments_id_seq'::regclass);
-
-
---
--- Name: active_storage_attachments id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.active_storage_attachments ALTER COLUMN id SET DEFAULT nextval('public.active_storage_attachments_id_seq'::regclass);
+ALTER TABLE ONLY active_admin_comments ALTER COLUMN id SET DEFAULT nextval('active_admin_comments_id_seq'::regclass);
 
 
 --
--- Name: active_storage_blobs id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.active_storage_blobs ALTER COLUMN id SET DEFAULT nextval('public.active_storage_blobs_id_seq'::regclass);
-
-
---
--- Name: addresses id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.addresses ALTER COLUMN id SET DEFAULT nextval('public.addresses_id_seq'::regclass);
+ALTER TABLE ONLY active_storage_attachments ALTER COLUMN id SET DEFAULT nextval('active_storage_attachments_id_seq'::regclass);
 
 
 --
--- Name: admin_permissions id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.admin_permissions ALTER COLUMN id SET DEFAULT nextval('public.admin_permissions_id_seq'::regclass);
-
-
---
--- Name: admin_role_permissions id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.admin_role_permissions ALTER COLUMN id SET DEFAULT nextval('public.admin_role_permissions_id_seq'::regclass);
+ALTER TABLE ONLY active_storage_blobs ALTER COLUMN id SET DEFAULT nextval('active_storage_blobs_id_seq'::regclass);
 
 
 --
--- Name: admin_roles id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.admin_roles ALTER COLUMN id SET DEFAULT nextval('public.admin_roles_id_seq'::regclass);
-
-
---
--- Name: admin_user_roles id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.admin_user_roles ALTER COLUMN id SET DEFAULT nextval('public.admin_user_roles_id_seq'::regclass);
+ALTER TABLE ONLY addresses ALTER COLUMN id SET DEFAULT nextval('addresses_id_seq'::regclass);
 
 
 --
--- Name: admin_users id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.admin_users ALTER COLUMN id SET DEFAULT nextval('public.admin_users_id_seq'::regclass);
-
-
---
--- Name: claim_claimants id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.claim_claimants ALTER COLUMN id SET DEFAULT nextval('public.claim_claimants_id_seq'::regclass);
+ALTER TABLE ONLY admin_permissions ALTER COLUMN id SET DEFAULT nextval('admin_permissions_id_seq'::regclass);
 
 
 --
--- Name: claim_representatives id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claim_representatives ALTER COLUMN id SET DEFAULT nextval('public.claim_representatives_id_seq'::regclass);
-
-
---
--- Name: claim_respondents id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.claim_respondents ALTER COLUMN id SET DEFAULT nextval('public.claim_respondents_id_seq'::regclass);
+ALTER TABLE ONLY admin_role_permissions ALTER COLUMN id SET DEFAULT nextval('admin_role_permissions_id_seq'::regclass);
 
 
 --
--- Name: claim_uploaded_files id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claim_uploaded_files ALTER COLUMN id SET DEFAULT nextval('public.claim_uploaded_files_id_seq'::regclass);
-
-
---
--- Name: claimants id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.claimants ALTER COLUMN id SET DEFAULT nextval('public.claimants_id_seq'::regclass);
+ALTER TABLE ONLY admin_roles ALTER COLUMN id SET DEFAULT nextval('admin_roles_id_seq'::regclass);
 
 
 --
--- Name: claims id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claims ALTER COLUMN id SET DEFAULT nextval('public.claims_id_seq'::regclass);
-
-
---
--- Name: et_acas_api_download_logs id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.et_acas_api_download_logs ALTER COLUMN id SET DEFAULT nextval('public.et_acas_api_download_logs_id_seq'::regclass);
+ALTER TABLE ONLY admin_user_roles ALTER COLUMN id SET DEFAULT nextval('admin_user_roles_id_seq'::regclass);
 
 
 --
--- Name: exported_files id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.exported_files ALTER COLUMN id SET DEFAULT nextval('public.exported_files_id_seq'::regclass);
-
-
---
--- Name: exports id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.exports ALTER COLUMN id SET DEFAULT nextval('public.exports_id_seq'::regclass);
+ALTER TABLE ONLY admin_users ALTER COLUMN id SET DEFAULT nextval('admin_users_id_seq'::regclass);
 
 
 --
--- Name: office_post_codes id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.office_post_codes ALTER COLUMN id SET DEFAULT nextval('public.office_post_codes_id_seq'::regclass);
-
-
---
--- Name: offices id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.offices ALTER COLUMN id SET DEFAULT nextval('public.offices_id_seq'::regclass);
+ALTER TABLE ONLY claim_claimants ALTER COLUMN id SET DEFAULT nextval('claim_claimants_id_seq'::regclass);
 
 
 --
--- Name: pre_allocated_file_keys id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pre_allocated_file_keys ALTER COLUMN id SET DEFAULT nextval('public.pre_allocated_file_keys_id_seq'::regclass);
-
-
---
--- Name: representatives id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.representatives ALTER COLUMN id SET DEFAULT nextval('public.representatives_id_seq'::regclass);
+ALTER TABLE ONLY claim_representatives ALTER COLUMN id SET DEFAULT nextval('claim_representatives_id_seq'::regclass);
 
 
 --
--- Name: respondents id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.respondents ALTER COLUMN id SET DEFAULT nextval('public.respondents_id_seq'::regclass);
-
-
---
--- Name: response_uploaded_files id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.response_uploaded_files ALTER COLUMN id SET DEFAULT nextval('public.response_uploaded_files_id_seq'::regclass);
+ALTER TABLE ONLY claim_respondents ALTER COLUMN id SET DEFAULT nextval('claim_respondents_id_seq'::regclass);
 
 
 --
--- Name: responses id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.responses ALTER COLUMN id SET DEFAULT nextval('public.responses_id_seq'::regclass);
-
-
---
--- Name: unique_references id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.unique_references ALTER COLUMN id SET DEFAULT nextval('public.unique_references_id_seq'::regclass);
+ALTER TABLE ONLY claim_uploaded_files ALTER COLUMN id SET DEFAULT nextval('claim_uploaded_files_id_seq'::regclass);
 
 
 --
--- Name: uploaded_files id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.uploaded_files ALTER COLUMN id SET DEFAULT nextval('public.uploaded_files_id_seq'::regclass);
+ALTER TABLE ONLY claimants ALTER COLUMN id SET DEFAULT nextval('claimants_id_seq'::regclass);
 
 
 --
--- Name: active_admin_comments active_admin_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.active_admin_comments
+ALTER TABLE ONLY claims ALTER COLUMN id SET DEFAULT nextval('claims_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY et_acas_api_download_logs ALTER COLUMN id SET DEFAULT nextval('et_acas_api_download_logs_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY exported_files ALTER COLUMN id SET DEFAULT nextval('exported_files_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY exports ALTER COLUMN id SET DEFAULT nextval('exports_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY office_post_codes ALTER COLUMN id SET DEFAULT nextval('office_post_codes_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY offices ALTER COLUMN id SET DEFAULT nextval('offices_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY pre_allocated_file_keys ALTER COLUMN id SET DEFAULT nextval('pre_allocated_file_keys_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY representatives ALTER COLUMN id SET DEFAULT nextval('representatives_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY respondents ALTER COLUMN id SET DEFAULT nextval('respondents_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY response_uploaded_files ALTER COLUMN id SET DEFAULT nextval('response_uploaded_files_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY responses ALTER COLUMN id SET DEFAULT nextval('responses_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY unique_references ALTER COLUMN id SET DEFAULT nextval('unique_references_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY uploaded_files ALTER COLUMN id SET DEFAULT nextval('uploaded_files_id_seq'::regclass);
+
+
+--
+-- Name: active_admin_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY active_admin_comments
     ADD CONSTRAINT active_admin_comments_pkey PRIMARY KEY (id);
 
 
 --
--- Name: active_storage_attachments active_storage_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: active_storage_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.active_storage_attachments
+ALTER TABLE ONLY active_storage_attachments
     ADD CONSTRAINT active_storage_attachments_pkey PRIMARY KEY (id);
 
 
 --
--- Name: active_storage_blobs active_storage_blobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: active_storage_blobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.active_storage_blobs
+ALTER TABLE ONLY active_storage_blobs
     ADD CONSTRAINT active_storage_blobs_pkey PRIMARY KEY (id);
 
 
 --
--- Name: addresses addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.addresses
+ALTER TABLE ONLY addresses
     ADD CONSTRAINT addresses_pkey PRIMARY KEY (id);
 
 
 --
--- Name: admin_permissions admin_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: admin_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.admin_permissions
+ALTER TABLE ONLY admin_permissions
     ADD CONSTRAINT admin_permissions_pkey PRIMARY KEY (id);
 
 
 --
--- Name: admin_role_permissions admin_role_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: admin_role_permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.admin_role_permissions
+ALTER TABLE ONLY admin_role_permissions
     ADD CONSTRAINT admin_role_permissions_pkey PRIMARY KEY (id);
 
 
 --
--- Name: admin_roles admin_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: admin_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.admin_roles
+ALTER TABLE ONLY admin_roles
     ADD CONSTRAINT admin_roles_pkey PRIMARY KEY (id);
 
 
 --
--- Name: admin_user_roles admin_user_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: admin_user_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.admin_user_roles
+ALTER TABLE ONLY admin_user_roles
     ADD CONSTRAINT admin_user_roles_pkey PRIMARY KEY (id);
 
 
 --
--- Name: admin_users admin_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: admin_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.admin_users
+ALTER TABLE ONLY admin_users
     ADD CONSTRAINT admin_users_pkey PRIMARY KEY (id);
 
 
 --
--- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ar_internal_metadata
+ALTER TABLE ONLY ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
 --
--- Name: claim_claimants claim_claimants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: claim_claimants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claim_claimants
+ALTER TABLE ONLY claim_claimants
     ADD CONSTRAINT claim_claimants_pkey PRIMARY KEY (id);
 
 
 --
--- Name: claim_representatives claim_representatives_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: claim_representatives_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claim_representatives
+ALTER TABLE ONLY claim_representatives
     ADD CONSTRAINT claim_representatives_pkey PRIMARY KEY (id);
 
 
 --
--- Name: claim_respondents claim_respondents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: claim_respondents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claim_respondents
+ALTER TABLE ONLY claim_respondents
     ADD CONSTRAINT claim_respondents_pkey PRIMARY KEY (id);
 
 
 --
--- Name: claim_uploaded_files claim_uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: claim_uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claim_uploaded_files
+ALTER TABLE ONLY claim_uploaded_files
     ADD CONSTRAINT claim_uploaded_files_pkey PRIMARY KEY (id);
 
 
 --
--- Name: claimants claimants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: claimants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claimants
+ALTER TABLE ONLY claimants
     ADD CONSTRAINT claimants_pkey PRIMARY KEY (id);
 
 
 --
--- Name: claims claims_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: claims_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claims
+ALTER TABLE ONLY claims
     ADD CONSTRAINT claims_pkey PRIMARY KEY (id);
 
 
 --
--- Name: et_acas_api_download_logs et_acas_api_download_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: et_acas_api_download_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.et_acas_api_download_logs
+ALTER TABLE ONLY et_acas_api_download_logs
     ADD CONSTRAINT et_acas_api_download_logs_pkey PRIMARY KEY (id);
 
 
 --
--- Name: exported_files exported_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: exported_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.exported_files
+ALTER TABLE ONLY exported_files
     ADD CONSTRAINT exported_files_pkey PRIMARY KEY (id);
 
 
 --
--- Name: exports exports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: exports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.exports
+ALTER TABLE ONLY exports
     ADD CONSTRAINT exports_pkey PRIMARY KEY (id);
 
 
 --
--- Name: office_post_codes office_post_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: office_post_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.office_post_codes
+ALTER TABLE ONLY office_post_codes
     ADD CONSTRAINT office_post_codes_pkey PRIMARY KEY (id);
 
 
 --
--- Name: offices offices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: offices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.offices
+ALTER TABLE ONLY offices
     ADD CONSTRAINT offices_pkey PRIMARY KEY (id);
 
 
 --
--- Name: pre_allocated_file_keys pre_allocated_file_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: pre_allocated_file_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pre_allocated_file_keys
+ALTER TABLE ONLY pre_allocated_file_keys
     ADD CONSTRAINT pre_allocated_file_keys_pkey PRIMARY KEY (id);
 
 
 --
--- Name: representatives representatives_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: representatives_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.representatives
+ALTER TABLE ONLY representatives
     ADD CONSTRAINT representatives_pkey PRIMARY KEY (id);
 
 
 --
--- Name: respondents respondents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: respondents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.respondents
+ALTER TABLE ONLY respondents
     ADD CONSTRAINT respondents_pkey PRIMARY KEY (id);
 
 
 --
--- Name: response_uploaded_files response_uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: response_uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.response_uploaded_files
+ALTER TABLE ONLY response_uploaded_files
     ADD CONSTRAINT response_uploaded_files_pkey PRIMARY KEY (id);
 
 
 --
--- Name: responses responses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: responses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.responses
+ALTER TABLE ONLY responses
     ADD CONSTRAINT responses_pkey PRIMARY KEY (id);
 
 
 --
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.schema_migrations
+ALTER TABLE ONLY schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
 --
--- Name: unique_references unique_references_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: unique_references_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.unique_references
+ALTER TABLE ONLY unique_references
     ADD CONSTRAINT unique_references_pkey PRIMARY KEY (id);
 
 
 --
--- Name: uploaded_files uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: uploaded_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.uploaded_files
+ALTER TABLE ONLY uploaded_files
     ADD CONSTRAINT uploaded_files_pkey PRIMARY KEY (id);
 
 
@@ -1435,351 +1436,351 @@ ALTER TABLE ONLY public.uploaded_files
 -- Name: index_active_admin_comments_on_author_type_and_author_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_active_admin_comments_on_author_type_and_author_id ON public.active_admin_comments USING btree (author_type, author_id);
+CREATE INDEX index_active_admin_comments_on_author_type_and_author_id ON active_admin_comments USING btree (author_type, author_id);
 
 
 --
 -- Name: index_active_admin_comments_on_namespace; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_active_admin_comments_on_namespace ON public.active_admin_comments USING btree (namespace);
+CREATE INDEX index_active_admin_comments_on_namespace ON active_admin_comments USING btree (namespace);
 
 
 --
 -- Name: index_active_admin_comments_on_resource_type_and_resource_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_active_admin_comments_on_resource_type_and_resource_id ON public.active_admin_comments USING btree (resource_type, resource_id);
+CREATE INDEX index_active_admin_comments_on_resource_type_and_resource_id ON active_admin_comments USING btree (resource_type, resource_id);
 
 
 --
 -- Name: index_active_storage_attachments_on_blob_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_active_storage_attachments_on_blob_id ON public.active_storage_attachments USING btree (blob_id);
+CREATE INDEX index_active_storage_attachments_on_blob_id ON active_storage_attachments USING btree (blob_id);
 
 
 --
 -- Name: index_active_storage_attachments_uniqueness; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON public.active_storage_attachments USING btree (record_type, record_id, name, blob_id);
+CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON active_storage_attachments USING btree (record_type, record_id, name, blob_id);
 
 
 --
 -- Name: index_active_storage_blobs_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON public.active_storage_blobs USING btree (key);
+CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON active_storage_blobs USING btree (key);
 
 
 --
 -- Name: index_admin_role_permissions_on_permission_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_admin_role_permissions_on_permission_id ON public.admin_role_permissions USING btree (permission_id);
+CREATE INDEX index_admin_role_permissions_on_permission_id ON admin_role_permissions USING btree (permission_id);
 
 
 --
 -- Name: index_admin_role_permissions_on_role_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_admin_role_permissions_on_role_id ON public.admin_role_permissions USING btree (role_id);
+CREATE INDEX index_admin_role_permissions_on_role_id ON admin_role_permissions USING btree (role_id);
 
 
 --
 -- Name: index_admin_user_roles_on_role_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_admin_user_roles_on_role_id ON public.admin_user_roles USING btree (role_id);
+CREATE INDEX index_admin_user_roles_on_role_id ON admin_user_roles USING btree (role_id);
 
 
 --
 -- Name: index_admin_user_roles_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_admin_user_roles_on_user_id ON public.admin_user_roles USING btree (user_id);
+CREATE INDEX index_admin_user_roles_on_user_id ON admin_user_roles USING btree (user_id);
 
 
 --
 -- Name: index_admin_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_admin_users_on_email ON public.admin_users USING btree (email);
+CREATE UNIQUE INDEX index_admin_users_on_email ON admin_users USING btree (email);
 
 
 --
 -- Name: index_admin_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_admin_users_on_reset_password_token ON public.admin_users USING btree (reset_password_token);
+CREATE UNIQUE INDEX index_admin_users_on_reset_password_token ON admin_users USING btree (reset_password_token);
 
 
 --
 -- Name: index_admin_users_on_unlock_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_admin_users_on_unlock_token ON public.admin_users USING btree (unlock_token);
+CREATE UNIQUE INDEX index_admin_users_on_unlock_token ON admin_users USING btree (unlock_token);
 
 
 --
 -- Name: index_admin_users_on_username; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_admin_users_on_username ON public.admin_users USING btree (username);
+CREATE UNIQUE INDEX index_admin_users_on_username ON admin_users USING btree (username);
 
 
 --
 -- Name: index_claim_claimants_on_claim_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_claim_claimants_on_claim_id ON public.claim_claimants USING btree (claim_id);
+CREATE INDEX index_claim_claimants_on_claim_id ON claim_claimants USING btree (claim_id);
 
 
 --
 -- Name: index_claim_claimants_on_claimant_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_claim_claimants_on_claimant_id ON public.claim_claimants USING btree (claimant_id);
+CREATE INDEX index_claim_claimants_on_claimant_id ON claim_claimants USING btree (claimant_id);
 
 
 --
 -- Name: index_claim_representatives_on_claim_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_claim_representatives_on_claim_id ON public.claim_representatives USING btree (claim_id);
+CREATE INDEX index_claim_representatives_on_claim_id ON claim_representatives USING btree (claim_id);
 
 
 --
 -- Name: index_claim_representatives_on_representative_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_claim_representatives_on_representative_id ON public.claim_representatives USING btree (representative_id);
+CREATE INDEX index_claim_representatives_on_representative_id ON claim_representatives USING btree (representative_id);
 
 
 --
 -- Name: index_claim_respondents_on_claim_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_claim_respondents_on_claim_id ON public.claim_respondents USING btree (claim_id);
+CREATE INDEX index_claim_respondents_on_claim_id ON claim_respondents USING btree (claim_id);
 
 
 --
 -- Name: index_claim_respondents_on_respondent_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_claim_respondents_on_respondent_id ON public.claim_respondents USING btree (respondent_id);
+CREATE INDEX index_claim_respondents_on_respondent_id ON claim_respondents USING btree (respondent_id);
 
 
 --
 -- Name: index_claim_uploaded_files_on_claim_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_claim_uploaded_files_on_claim_id ON public.claim_uploaded_files USING btree (claim_id);
+CREATE INDEX index_claim_uploaded_files_on_claim_id ON claim_uploaded_files USING btree (claim_id);
 
 
 --
 -- Name: index_claim_uploaded_files_on_uploaded_file_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_claim_uploaded_files_on_uploaded_file_id ON public.claim_uploaded_files USING btree (uploaded_file_id);
+CREATE INDEX index_claim_uploaded_files_on_uploaded_file_id ON claim_uploaded_files USING btree (uploaded_file_id);
 
 
 --
 -- Name: index_claimants_on_address_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_claimants_on_address_id ON public.claimants USING btree (address_id);
+CREATE INDEX index_claimants_on_address_id ON claimants USING btree (address_id);
 
 
 --
 -- Name: index_exports_on_resource_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_exports_on_resource_id ON public.exports USING btree (resource_id);
+CREATE INDEX index_exports_on_resource_id ON exports USING btree (resource_id);
 
 
 --
 -- Name: index_office_post_codes_on_office_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_office_post_codes_on_office_id ON public.office_post_codes USING btree (office_id);
+CREATE INDEX index_office_post_codes_on_office_id ON office_post_codes USING btree (office_id);
 
 
 --
 -- Name: index_pre_allocated_file_keys_to_allocated_id_and_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_pre_allocated_file_keys_to_allocated_id_and_type ON public.pre_allocated_file_keys USING btree (allocated_to_type, allocated_to_id);
+CREATE INDEX index_pre_allocated_file_keys_to_allocated_id_and_type ON pre_allocated_file_keys USING btree (allocated_to_type, allocated_to_id);
 
 
 --
 -- Name: index_representatives_on_address_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_representatives_on_address_id ON public.representatives USING btree (address_id);
+CREATE INDEX index_representatives_on_address_id ON representatives USING btree (address_id);
 
 
 --
 -- Name: index_respondents_on_address_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_respondents_on_address_id ON public.respondents USING btree (address_id);
+CREATE INDEX index_respondents_on_address_id ON respondents USING btree (address_id);
 
 
 --
 -- Name: index_respondents_on_work_address_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_respondents_on_work_address_id ON public.respondents USING btree (work_address_id);
+CREATE INDEX index_respondents_on_work_address_id ON respondents USING btree (work_address_id);
 
 
 --
 -- Name: index_response_uploaded_files_on_response_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_response_uploaded_files_on_response_id ON public.response_uploaded_files USING btree (response_id);
+CREATE INDEX index_response_uploaded_files_on_response_id ON response_uploaded_files USING btree (response_id);
 
 
 --
 -- Name: index_response_uploaded_files_on_uploaded_file_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_response_uploaded_files_on_uploaded_file_id ON public.response_uploaded_files USING btree (uploaded_file_id);
+CREATE INDEX index_response_uploaded_files_on_uploaded_file_id ON response_uploaded_files USING btree (uploaded_file_id);
 
 
 --
 -- Name: index_responses_on_representative_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_responses_on_representative_id ON public.responses USING btree (representative_id);
+CREATE INDEX index_responses_on_representative_id ON responses USING btree (representative_id);
 
 
 --
 -- Name: index_responses_on_respondent_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_responses_on_respondent_id ON public.responses USING btree (respondent_id);
+CREATE INDEX index_responses_on_respondent_id ON responses USING btree (respondent_id);
 
 
 --
--- Name: claim_representatives fk_rails_303e8e36aa; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_303e8e36aa; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claim_representatives
-    ADD CONSTRAINT fk_rails_303e8e36aa FOREIGN KEY (representative_id) REFERENCES public.representatives(id);
-
-
---
--- Name: claim_claimants fk_rails_3b2aad2c6b; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.claim_claimants
-    ADD CONSTRAINT fk_rails_3b2aad2c6b FOREIGN KEY (claim_id) REFERENCES public.claims(id);
+ALTER TABLE ONLY claim_representatives
+    ADD CONSTRAINT fk_rails_303e8e36aa FOREIGN KEY (representative_id) REFERENCES representatives(id);
 
 
 --
--- Name: claimants fk_rails_5b676c7564; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_3b2aad2c6b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claimants
-    ADD CONSTRAINT fk_rails_5b676c7564 FOREIGN KEY (address_id) REFERENCES public.addresses(id);
-
-
---
--- Name: claim_representatives fk_rails_6b02086897; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.claim_representatives
-    ADD CONSTRAINT fk_rails_6b02086897 FOREIGN KEY (claim_id) REFERENCES public.claims(id);
+ALTER TABLE ONLY claim_claimants
+    ADD CONSTRAINT fk_rails_3b2aad2c6b FOREIGN KEY (claim_id) REFERENCES claims(id);
 
 
 --
--- Name: representatives fk_rails_6e31f27150; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_5b676c7564; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.representatives
-    ADD CONSTRAINT fk_rails_6e31f27150 FOREIGN KEY (address_id) REFERENCES public.addresses(id);
-
-
---
--- Name: claim_respondents fk_rails_6f891eb8c6; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.claim_respondents
-    ADD CONSTRAINT fk_rails_6f891eb8c6 FOREIGN KEY (respondent_id) REFERENCES public.respondents(id);
+ALTER TABLE ONLY claimants
+    ADD CONSTRAINT fk_rails_5b676c7564 FOREIGN KEY (address_id) REFERENCES addresses(id);
 
 
 --
--- Name: claim_uploaded_files fk_rails_aef838d57f; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_6b02086897; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claim_uploaded_files
-    ADD CONSTRAINT fk_rails_aef838d57f FOREIGN KEY (uploaded_file_id) REFERENCES public.uploaded_files(id);
-
-
---
--- Name: respondents fk_rails_b2834e6387; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.respondents
-    ADD CONSTRAINT fk_rails_b2834e6387 FOREIGN KEY (address_id) REFERENCES public.addresses(id);
+ALTER TABLE ONLY claim_representatives
+    ADD CONSTRAINT fk_rails_6b02086897 FOREIGN KEY (claim_id) REFERENCES claims(id);
 
 
 --
--- Name: claim_respondents fk_rails_c38ecd1031; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_6e31f27150; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claim_respondents
-    ADD CONSTRAINT fk_rails_c38ecd1031 FOREIGN KEY (claim_id) REFERENCES public.claims(id);
-
-
---
--- Name: claim_uploaded_files fk_rails_c95be0dd75; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.claim_uploaded_files
-    ADD CONSTRAINT fk_rails_c95be0dd75 FOREIGN KEY (claim_id) REFERENCES public.claims(id);
+ALTER TABLE ONLY representatives
+    ADD CONSTRAINT fk_rails_6e31f27150 FOREIGN KEY (address_id) REFERENCES addresses(id);
 
 
 --
--- Name: response_uploaded_files fk_rails_caf1d8fe35; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_6f891eb8c6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.response_uploaded_files
-    ADD CONSTRAINT fk_rails_caf1d8fe35 FOREIGN KEY (response_id) REFERENCES public.responses(id);
-
-
---
--- Name: office_post_codes fk_rails_d276fbe15b; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.office_post_codes
-    ADD CONSTRAINT fk_rails_d276fbe15b FOREIGN KEY (office_id) REFERENCES public.offices(id);
+ALTER TABLE ONLY claim_respondents
+    ADD CONSTRAINT fk_rails_6f891eb8c6 FOREIGN KEY (respondent_id) REFERENCES respondents(id);
 
 
 --
--- Name: respondents fk_rails_d2d3e755fa; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_aef838d57f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.respondents
-    ADD CONSTRAINT fk_rails_d2d3e755fa FOREIGN KEY (work_address_id) REFERENCES public.addresses(id);
-
-
---
--- Name: response_uploaded_files fk_rails_e34b7bdec4; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.response_uploaded_files
-    ADD CONSTRAINT fk_rails_e34b7bdec4 FOREIGN KEY (uploaded_file_id) REFERENCES public.uploaded_files(id);
+ALTER TABLE ONLY claim_uploaded_files
+    ADD CONSTRAINT fk_rails_aef838d57f FOREIGN KEY (uploaded_file_id) REFERENCES uploaded_files(id);
 
 
 --
--- Name: claim_claimants fk_rails_fc3432143b; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: fk_rails_b2834e6387; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.claim_claimants
-    ADD CONSTRAINT fk_rails_fc3432143b FOREIGN KEY (claimant_id) REFERENCES public.claimants(id);
+ALTER TABLE ONLY respondents
+    ADD CONSTRAINT fk_rails_b2834e6387 FOREIGN KEY (address_id) REFERENCES addresses(id);
+
+
+--
+-- Name: fk_rails_c38ecd1031; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY claim_respondents
+    ADD CONSTRAINT fk_rails_c38ecd1031 FOREIGN KEY (claim_id) REFERENCES claims(id);
+
+
+--
+-- Name: fk_rails_c95be0dd75; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY claim_uploaded_files
+    ADD CONSTRAINT fk_rails_c95be0dd75 FOREIGN KEY (claim_id) REFERENCES claims(id);
+
+
+--
+-- Name: fk_rails_caf1d8fe35; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY response_uploaded_files
+    ADD CONSTRAINT fk_rails_caf1d8fe35 FOREIGN KEY (response_id) REFERENCES responses(id);
+
+
+--
+-- Name: fk_rails_d276fbe15b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY office_post_codes
+    ADD CONSTRAINT fk_rails_d276fbe15b FOREIGN KEY (office_id) REFERENCES offices(id);
+
+
+--
+-- Name: fk_rails_d2d3e755fa; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY respondents
+    ADD CONSTRAINT fk_rails_d2d3e755fa FOREIGN KEY (work_address_id) REFERENCES addresses(id);
+
+
+--
+-- Name: fk_rails_e34b7bdec4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY response_uploaded_files
+    ADD CONSTRAINT fk_rails_e34b7bdec4 FOREIGN KEY (uploaded_file_id) REFERENCES uploaded_files(id);
+
+
+--
+-- Name: fk_rails_fc3432143b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY claim_claimants
+    ADD CONSTRAINT fk_rails_fc3432143b FOREIGN KEY (claimant_id) REFERENCES claimants(id);
 
 
 --
@@ -1827,6 +1828,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180719143301'),
 ('20180720100511'),
 ('20180721164447'),
-('20180722080012');
+('20180722080012'),
+('20180731090130'),
+('20180828120205');
 
 

--- a/spec/factories/claim_claimant_factory.rb
+++ b/spec/factories/claim_claimant_factory.rb
@@ -1,0 +1,54 @@
+FactoryBot.define do
+  factory :claim_claimant do
+    primary false
+    claimant { build(:claimant, :example_data) }
+
+    trait :example_data do
+      claimant { build(:claimant, :example_data) }
+    end
+
+    trait :tamara_swift do
+      claimant { build(:claimant, :tamara_swift) }
+    end
+
+    trait :diana_flatley do
+      claimant { build(:claimant, :diana_flatley) }
+    end
+
+    trait :mariana_mccullough do
+      claimant { build(:claimant, :mariana_mccullough) }
+    end
+
+    trait :eden_upton do
+      claimant { build(:claimant, :eden_upton) }
+    end
+
+    trait :annie_schulist do
+      claimant { build(:claimant, :annie_schulist) }
+    end
+
+    trait :thad_johns do
+      claimant { build(:claimant, :thad_johns) }
+    end
+
+    trait :coleman_kreiger do
+      claimant { build(:claimant, :coleman_kreiger) }
+    end
+
+    trait :jenson_deckow do
+      claimant { build(:claimant, :jenson_deckow) }
+    end
+
+    trait :darien_bahringer do
+      claimant { build(:claimant, :darien_bahringer) }
+    end
+
+    trait :eulalia_hammes do
+      claimant { build(:claimant, :eulalia_hammes) }
+    end
+
+    trait :mr_na_o_malley do
+      claimant { build(:claimant, :mr_na_o_malley) }
+    end
+  end
+end

--- a/spec/factories/claim_factory.rb
+++ b/spec/factories/claim_factory.rb
@@ -19,7 +19,8 @@ FactoryBot.define do
     date_of_receipt { Time.zone.now }
 
     after(:build) do |claim, evaluator|
-      claim.claimants.concat build_list(:claimant, evaluator.number_of_claimants)
+      claim.claim_claimants.concat build_list(:claim_claimant, evaluator.number_of_claimants)
+      claim.claim_claimants.last.primary = true
       claim.claimant_count += evaluator.number_of_claimants
     end
 
@@ -64,7 +65,7 @@ FactoryBot.define do
       reference "222000000300"
       date_of_receipt { Time.zone.parse('29/3/2018') }
       number_of_claimants 0
-      claimants { [build(:claimant, :example_data)] }
+      claim_claimants { [build(:claim_claimant, :example_data)] }
       respondents { [build(:respondent, :example_data)] }
       representatives { [build(:representative, :example_data)] }
       uploaded_files { [build(:uploaded_file, :example_data)] }
@@ -72,19 +73,19 @@ FactoryBot.define do
 
     trait :example_data_multiple_claimants do
       example_data
-      claimants do
+      claim_claimants do
         [
-          build(:claimant, :example_data),
-          build(:claimant, :tamara_swift),
-          build(:claimant, :diana_flatley),
-          build(:claimant, :mariana_mccullough),
-          build(:claimant, :eden_upton),
-          build(:claimant, :annie_schulist),
-          build(:claimant, :thad_johns),
-          build(:claimant, :coleman_kreiger),
-          build(:claimant, :jenson_deckow),
-          build(:claimant, :darien_bahringer),
-          build(:claimant, :eulalia_hammes)
+          build(:claim_claimant, :example_data, primary: true),
+          build(:claim_claimant, :tamara_swift),
+          build(:claim_claimant, :diana_flatley),
+          build(:claim_claimant, :mariana_mccullough),
+          build(:claim_claimant, :eden_upton),
+          build(:claim_claimant, :annie_schulist),
+          build(:claim_claimant, :thad_johns),
+          build(:claim_claimant, :coleman_kreiger),
+          build(:claim_claimant, :jenson_deckow),
+          build(:claim_claimant, :darien_bahringer),
+          build(:claim_claimant, :eulalia_hammes)
         ]
       end
       uploaded_files { [build(:uploaded_file, :example_data), build(:uploaded_file, :example_claim_claimants_csv)] }

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -7,23 +7,26 @@ RSpec.describe Claim, type: :model do
 
   let(:claim) { described_class.new }
 
-  describe '#claimants' do
-    it 'returns claimants built in memory' do
+  describe '#claim_claimants' do
+    it 'returns claim - claimants built in memory' do
       # Arrange
-      claim.claimants_attributes = [
+      claim.claim_claimants_attributes = [
         {
-          title: 'Mr',
-          first_name: 'Fred',
-          last_name: 'Bloggs',
-          address_attributes: example_address_attrs
+          primary: true,
+          claimant_attributes: {
+            title: 'Mr',
+            first_name: 'Fred',
+            last_name: 'Bloggs',
+            address_attributes: example_address_attrs
+          }
         }
       ]
 
       # Act
-      results = claim.claimants
+      results = claim.claim_claimants
 
       # Assert
-      expect(results).to contain_exactly an_object_having_attributes first_name: 'Fred', last_name: 'Bloggs'
+      expect(results).to contain_exactly an_object_having_attributes primary: true, claimant: an_object_having_attributes(first_name: 'Fred', last_name: 'Bloggs')
     end
   end
 
@@ -90,18 +93,24 @@ RSpec.describe Claim, type: :model do
   describe 'claimant_count' do
     it 'returns the number of claimants built at initialisation time' do
       # Arrange
-      claim.claimants_attributes = [
+      claim.claim_claimants_attributes = [
         {
-          title: 'Mr',
-          first_name: 'Fred',
-          last_name: 'Bloggs',
-          address_attributes: example_address_attrs
+          primary: true,
+          claimant_attributes: {
+            title: 'Mr',
+            first_name: 'Fred',
+            last_name: 'Bloggs',
+            address_attributes: example_address_attrs
+          }
         },
         {
-          title: 'Mrs',
-          first_name: 'Sara',
-          last_name: 'Bloggs',
-          address_attributes: example_address_attrs
+          primary: false,
+          claimant_attributes: {
+            title: 'Mrs',
+            first_name: 'Sara',
+            last_name: 'Bloggs',
+            address_attributes: example_address_attrs
+          }
         }
       ]
 

--- a/spec/requests/v1/create_claim_spec.rb
+++ b/spec/requests/v1/create_claim_spec.rb
@@ -74,11 +74,12 @@ RSpec.describe 'CreateClaim Request', type: :request do
       # A private scrubber to set expectations for the filename - replaces white space with underscores and any non word chars are removed
       scrubber = ->(text) { text.gsub(/\s/, '_').gsub(/\W/, '') }
 
-      let(:output_filename_pdf) { "#{json_response['feeGroupReference']}_ET1_#{scrubber.call xml_as_hash.claimants.first.forename}_#{scrubber.call xml_as_hash.claimants.first.surname}.pdf" }
-      let(:output_filename_txt) { "#{json_response['feeGroupReference']}_ET1_#{scrubber.call xml_as_hash.claimants.first.forename}_#{scrubber.call xml_as_hash.claimants.first.surname}.txt" }
-      let(:output_filename_rtf) { "#{json_response['feeGroupReference']}_ET1_Attachment_#{scrubber.call xml_as_hash.claimants.first.forename}_#{scrubber.call xml_as_hash.claimants.first.surname}.rtf" }
-      let(:output_filename_additional_claimants_txt) { "#{json_response['feeGroupReference']}_ET1a_#{scrubber.call xml_as_hash.claimants.first.forename}_#{scrubber.call xml_as_hash.claimants.first.surname}.txt" }
-      let(:output_filename_additional_claimants_csv) { "#{json_response['feeGroupReference']}_ET1a_#{scrubber.call xml_as_hash.claimants.first.forename}_#{scrubber.call xml_as_hash.claimants.first.surname}.csv" }
+      let(:xml_primary_claimant) { xml_as_hash.claimants.detect(&:group_contact) }
+      let(:output_filename_pdf) { "#{json_response['feeGroupReference']}_ET1_#{scrubber.call xml_primary_claimant.forename}_#{scrubber.call xml_primary_claimant.surname}.pdf" }
+      let(:output_filename_txt) { "#{json_response['feeGroupReference']}_ET1_#{scrubber.call xml_primary_claimant.forename}_#{scrubber.call xml_primary_claimant.surname}.txt" }
+      let(:output_filename_rtf) { "#{json_response['feeGroupReference']}_ET1_Attachment_#{scrubber.call xml_primary_claimant.forename}_#{scrubber.call xml_primary_claimant.surname}.rtf" }
+      let(:output_filename_additional_claimants_txt) { "#{json_response['feeGroupReference']}_ET1a_#{scrubber.call xml_primary_claimant.forename}_#{scrubber.call xml_primary_claimant.surname}.txt" }
+      let(:output_filename_additional_claimants_csv) { "#{json_response['feeGroupReference']}_ET1a_#{scrubber.call xml_primary_claimant.forename}_#{scrubber.call xml_primary_claimant.surname}.csv" }
 
       before do
         perform_action
@@ -136,7 +137,7 @@ RSpec.describe 'CreateClaim Request', type: :request do
       it 'has the primary claimant in the et1 txt file' do
         # Assert - look for the correct file in the landing folder - will be async
         #
-        claimant = normalize_xml_hash(xml_as_hash.as_json)[:claimants].first
+        claimant = normalize_xml_claimant(xml_primary_claimant.to_xml.to_h)
         expect(staging_folder.et1_txt_file(output_filename_txt)).to have_claimant_for(claimant, errors: errors), -> { errors.join("\n") }
       end
 
@@ -193,12 +194,16 @@ RSpec.describe 'CreateClaim Request', type: :request do
 
       it 'stores an ET1a txt file with the correct header for the given input data' do
         claim = normalize_xml_hash(xml_as_hash.as_json)
-        expect(staging_folder.et1a_txt_file(output_filename_additional_claimants_txt)).to have_header_for(claim, errors: errors), -> { errors.join("\n") }
+        claimant = normalize_xml_claimant(xml_primary_claimant.to_xml.to_h)
+        expect(staging_folder.et1a_txt_file(output_filename_additional_claimants_txt)).to have_header_for(claim, primary_claimant: claimant, errors: errors), -> { errors.join("\n") }
       end
 
       it 'stores an ET1a txt file with all of the claimants in the correct format' do
         # Assert
-        claimants = normalize_xml_hash(xml_as_hash.as_json)[:claimants][1..-1]
+        claimant = normalize_xml_claimant(xml_primary_claimant.to_xml.to_h)
+        claimants = normalize_xml_hash(xml_as_hash.as_json)[:claimants].reject do |c|
+          c == claimant
+        end
         expect(staging_folder.et1a_txt_file(output_filename_additional_claimants_txt)).to have_claimants_for(claimants, errors: errors), -> { errors.join("\n") }
       end
     end

--- a/spec/services/claim_file_builder/build_claim_text_file_spec.rb
+++ b/spec/services/claim_file_builder/build_claim_text_file_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ClaimFileBuilder::BuildClaimTextFile do
 
   describe '#call' do
     context 'with a single claimant, respondent and representative' do
-      let(:claim) { build(:claim, :example_data) }
+      let(:claim) { create(:claim, :example_data) }
 
       it 'stores an ET1 txt file with the correct filename' do
         # Act

--- a/spec/services/claim_file_builder/build_claimants_text_file_spec.rb
+++ b/spec/services/claim_file_builder/build_claimants_text_file_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ClaimFileBuilder::BuildClaimantsTextFile do
 
   describe '#call' do
     context 'with 11 claimants, 1 respondent and representative' do
-      let(:claim) { build(:claim, :example_data_multiple_claimants) }
+      let(:claim) { create(:claim, :example_data_multiple_claimants) }
 
       it 'stores an ET1a txt file with the correct filename' do
         # Act

--- a/spec/services/claim_xml_import_service_spec.rb
+++ b/spec/services/claim_xml_import_service_spec.rb
@@ -71,22 +71,47 @@ RSpec.describe ClaimXmlImportService do
 
         # Assert
         claim = Claim.where(reference: reference).first
-        expect(claim.claimants).to contain_exactly an_object_having_attributes title: 'Mr',
-                                                                               first_name: 'First',
-                                                                               last_name: 'Last',
-                                                                               address: an_object_having_attributes(
-                                                                                 building: '102',
-                                                                                 street: 'Petty France',
-                                                                                 locality: 'London',
-                                                                                 county: 'Greater London',
-                                                                                 post_code: 'SW1H 9AJ'
-                                                                               ),
-                                                                               address_telephone_number: '01234 567890',
-                                                                               mobile_number: '01234 098765',
-                                                                               email_address: 'test@digital.justice.gov.uk',
-                                                                               contact_preference: 'Email',
-                                                                               gender: 'Male',
-                                                                               date_of_birth: Date.parse('21/11/1982')
+        expect(claim.claim_claimants).to contain_exactly an_object_having_attributes primary: true,
+                                                                                     claimant: an_object_having_attributes(title: 'Mr',
+                                                                                                                           first_name: 'First',
+                                                                                                                           last_name: 'Last',
+                                                                                                                           address: an_object_having_attributes(
+                                                                                                                             building: '102',
+                                                                                                                             street: 'Petty France',
+                                                                                                                             locality: 'London',
+                                                                                                                             county: 'Greater London',
+                                                                                                                             post_code: 'SW1H 9AJ'
+                                                                                                                           ),
+                                                                                                                           address_telephone_number: '01234 567890',
+                                                                                                                           mobile_number: '01234 098765',
+                                                                                                                           email_address: 'test@digital.justice.gov.uk',
+                                                                                                                           contact_preference: 'Email',
+                                                                                                                           gender: 'Male',
+                                                                                                                           date_of_birth: Date.parse('21/11/1982'))
+      end
+
+      it 'converts the primary claimant correctly' do
+        # Act
+        service.import(into: destination_claim)
+
+        # Assert
+        claim = Claim.where(reference: reference).first
+        expect(claim.primary_claimant).to have_attributes title: 'Mr',
+                                                          first_name: 'First',
+                                                          last_name: 'Last',
+                                                          address: an_object_having_attributes(
+                                                            building: '102',
+                                                            street: 'Petty France',
+                                                            locality: 'London',
+                                                            county: 'Greater London',
+                                                            post_code: 'SW1H 9AJ'
+                                                          ),
+                                                          address_telephone_number: '01234 567890',
+                                                          mobile_number: '01234 098765',
+                                                          email_address: 'test@digital.justice.gov.uk',
+                                                          contact_preference: 'Email',
+                                                          gender: 'Male',
+                                                          date_of_birth: Date.parse('21/11/1982')
       end
 
       it 'converts the respondents correctly' do
@@ -203,7 +228,7 @@ RSpec.describe ClaimXmlImportService do
 
         # Assert
         claim = Claim.where(reference: reference).first
-        expect(claim.claimants).to contain_exactly an_object_having_attributes(title: 'Mr', first_name: 'First', last_name: 'Last'),
+        expect(claim.claim_claimants.map(&:claimant)).to contain_exactly an_object_having_attributes(title: 'Mr', first_name: 'First', last_name: 'Last'),
           an_object_having_attributes(title: 'Mrs', first_name: 'tamara', last_name: 'swift'),
           an_object_having_attributes(title: 'Mr', first_name: 'diana', last_name: 'flatley'),
           an_object_having_attributes(title: 'Ms', first_name: 'mariana', last_name: 'mccullough'),

--- a/spec/support/landing_folder_support/file_objects/et1a_txt_file.rb
+++ b/spec/support/landing_folder_support/file_objects/et1a_txt_file.rb
@@ -91,11 +91,11 @@ module EtApi
         rescue RSpec::Expectations::ExpectationNotMetError => err
           errors << "Missing or invalid claimants section - checking index #{idx}"
           errors.concat(err.message.lines.map { |l| "#{'  ' * indent}#{l.gsub(/\n\z/, '')}" })
-          false
+          idx
         end
 
-        def has_header_for?(claim, errors: [], indent: 1) # rubocop:disable Naming/PredicateName
-          claimant = claim[:claimants].first
+        def has_header_for?(claim, primary_claimant:, errors: [], indent: 1) # rubocop:disable Naming/PredicateName
+          claimant = primary_claimant
           respondent = claim[:respondents].first
           has_header_section? errors: errors, indent: indent,
                               reference: end_with(claim[:reference]),


### PR DESCRIPTION
The claim importer now correctly marks the appropriate claimant as primary
The claim no longer supports using claimants directly, instead it expects the use of claim_claimants with the extra column