### PR TITLE
Preparation for release 1.4.0 Continued

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://codeclimate.com/github/ministryofjustice/et_api/test_coverage"><img src="https://api.codeclimate.com/v1/badges/1229a56ce687e1a1376d/test_coverage" /></a>
 
-The API server for the ET service including ET1 and ET3 (WORK IN PROGRESS)
+The API server for the ET service including ET1 and ET3
 
 ## Introduction
 

--- a/app/services/claim_file_builder/build_response_pdf_file.rb
+++ b/app/services/claim_file_builder/build_response_pdf_file.rb
@@ -169,11 +169,9 @@ module ClaimFileBuilder
     end
 
     def apply_disability_pdf_fields(result)
-      representative = response.representative
-      return apply_no_disability_pdf_fields(result) if representative.nil?
-      return if representative.nil?
-      result['8.1 tick box'] = tri_state_value_for(representative.disability)
-      result['8.1 if yes'] = representative.disability_information
+      respondent = response.respondent
+      result['8.1 tick box'] = tri_state_value_for(respondent.disability)
+      result['8.1 if yes'] = respondent.disability_information
     end
 
     def apply_no_disability_pdf_fields(result)

--- a/db/migrate/20180903102740_add_disability_to_respondents.rb
+++ b/db/migrate/20180903102740_add_disability_to_respondents.rb
@@ -1,0 +1,6 @@
+class AddDisabilityToRespondents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :respondents, :disability, :boolean
+    add_column :respondents, :disability_information, :string
+  end
+end

--- a/db/migrate/20180903102828_copy_disability_from_representatives.rb
+++ b/db/migrate/20180903102828_copy_disability_from_representatives.rb
@@ -1,0 +1,34 @@
+class CopyDisabilityFromRepresentatives < ActiveRecord::Migration[5.2]
+  class Response < ActiveRecord::Base
+    belongs_to :respondent, class_name: '::CopyDisabilityFromRepresentatives::Respondent'
+    belongs_to :representative, optional: true, class_name: '::CopyDisabilityFromRepresentatives::Representative'
+  end
+
+  class Representative < ActiveRecord::Base
+
+  end
+
+  class Respondent < ActiveRecord::Base
+
+  end
+
+  def up
+    Response.all.each do |response|
+      rep = response.representative
+      next if rep.nil?
+      resp = response.respondent
+      resp.update disability: rep.disability, disability_information: rep.disability_information
+    end
+
+  end
+
+  def down
+    Response.all.each do |response|
+      rep = response.representative
+      next if rep.nil?
+      resp = response.respondent
+      rep.update disability: resp.disability, disability_information: resp.disability_information
+    end
+
+  end
+end

--- a/db/migrate/20180903104122_drop_disability_from_representatives.rb
+++ b/db/migrate/20180903104122_drop_disability_from_representatives.rb
@@ -1,0 +1,6 @@
+class DropDisabilityFromRepresentatives < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :representatives, :disability
+    remove_column :representatives, :disability_information
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -819,9 +819,7 @@ CREATE TABLE representatives (
     updated_at timestamp without time zone NOT NULL,
     reference character varying,
     contact_preference character varying,
-    fax_number character varying,
-    disability boolean,
-    disability_information character varying
+    fax_number character varying
 );
 
 
@@ -866,7 +864,9 @@ CREATE TABLE respondents (
     fax_number character varying,
     organisation_employ_gb integer,
     organisation_more_than_one_site boolean,
-    employment_at_site_number integer
+    employment_at_site_number integer,
+    disability boolean,
+    disability_information character varying
 );
 
 
@@ -1908,6 +1908,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180828120205'),
 ('20180828162908'),
 ('20180829121912'),
-('20180829143635');
+('20180829143635'),
+('20180903102740'),
+('20180903102828'),
+('20180903104122');
 
 

--- a/spec/factories/json/json_response_factory.rb
+++ b/spec/factories/json/json_response_factory.rb
@@ -127,6 +127,8 @@ FactoryBot.define do
       fax_number ''
       organisation_employ_gb 10
       employment_at_site_number 5
+      disability true
+      disability_information 'Lorem ipsum disability'
     end
   end
 
@@ -153,8 +155,6 @@ FactoryBot.define do
       contact_preference 'fax'
       email_address ''
       fax_number '0207 345 6789'
-      disability true
-      disability_information 'Lorem ipsum disability'
     end
   end
 

--- a/spec/factories/representative_factory.rb
+++ b/spec/factories/representative_factory.rb
@@ -21,8 +21,6 @@ FactoryBot.define do
       reference 'solicitor-reference'
       contact_preference 'email'
       fax_number '02222 222222'
-      disability_information ''
-      disability false
     end
   end
 end

--- a/spec/factories/respondent_factory.rb
+++ b/spec/factories/respondent_factory.rb
@@ -33,6 +33,8 @@ FactoryBot.define do
       organisation_employ_gb 10
       organisation_more_than_one_site true
       employment_at_site_number 5
+      disability_information ''
+      disability false
     end
 
     trait :mr_na_o_malley do

--- a/spec/support/landing_folder_support/file_objects/et3_pdf_file.rb
+++ b/spec/support/landing_folder_support/file_objects/et3_pdf_file.rb
@@ -20,7 +20,7 @@ module EtApi
             has_response_for?(response, errors: errors, indent: indent) &&
             has_contract_claim_for?(response, errors: errors, indent: indent) &&
             has_representative_for?(representative, errors: errors, indent: indent) &&
-            has_disability_for?(representative, errors: errors, indent: indent)
+            has_disability_for?(respondent, errors: errors, indent: indent)
         end
 
         def has_correct_contents_from_db_for?(response:, errors: [], indent: 1)
@@ -158,11 +158,10 @@ module EtApi
           end
         end
 
-        def has_disability_for?(representative, errors: [], indent: 1)
-          return has_no_disability?(errors: errors, indent: indent) if representative.nil?
+        def has_disability_for?(respondent, errors: [], indent: 1)
           validate_fields section: :disability, errors: errors, indent: indent do
-            expect(field_values).to include '8.1 tick box' => tri_state_value_for(representative[:disability])
-            expect(field_values).to include '8.1 if yes' => representative[:disability_information] || ''
+            expect(field_values).to include '8.1 tick box' => tri_state_value_for(respondent[:disability])
+            expect(field_values).to include '8.1 if yes' => respondent[:disability_information] || ''
           end
         end
 


### PR DESCRIPTION
## New Functionality

None

## Bug Fixes

None

## Changes

- RST-1377 - Breaking Change - Move disability information from representative to the respondent.  This is accompanied by a release of ET3 which will happen at the same time