### PR TITLE
RST-1354 - Encoding Issues

### DIFF
--- a/app/services/claim_file_builder/render_to_file.rb
+++ b/app/services/claim_file_builder/render_to_file.rb
@@ -5,7 +5,7 @@ module ClaimFileBuilder
     class_methods do
 
       def render_to_file(object:)
-        Tempfile.new.tap do |file|
+        Tempfile.new(encoding: 'windows-1252').tap do |file|
           file.write with_windows_lf(render(object))
           file.rewind
         end

--- a/spec/factories/xml/xml_claim_factory.rb
+++ b/spec/factories/xml/xml_claim_factory.rb
@@ -137,6 +137,8 @@ FactoryBot.define do
       if r.primary_claimant.blank?
         r.primary_claimant = build(:xml_claimant, claimants_list.first)
       end
+      r.primary_claimant.group_contact = true
+
       unless r.secondary_claimants.is_a?(Array)
         r.secondary_claimants = []
         evaluator.number_of_secondary_claimants.times do |idx|
@@ -469,6 +471,29 @@ FactoryBot.define do
       sex ''
       date_of_birth '04/10/1998'
     end
+
+    # Latoya has a utf-8 apostrophe in her address just to be a bit awkward
+    trait :latoya_bishop do
+      group_contact false
+      title "Mrs"
+      forename "latoya"
+      surname "bishop"
+      association :address, factory: :xml_claim_address,
+                            line: '24',
+                            street: 'St John’s Lane',
+                            town: 'Birmingham',
+                            county: 'West Midlands',
+                            postcode: 'B2 6YK'
+      office_number ''
+      alt_phone_number ''
+      email ''
+      fax nil
+      preferred_contact_method ''
+      sex ''
+      date_of_birth '04/11/1994'
+    end
+
+
   end
 
   factory :xml_claim_respondent, class: ::EtApi::Test::XML::Node do
@@ -569,6 +594,14 @@ FactoryBot.define do
       town 'London'
       county 'Greater London'
       postcode 'SW1H 9AJ'
+    end
+
+    trait :st_johns_lane do
+      line '64'
+      street 'St John’s Lane'
+      town 'Birmingham'
+      county 'West Midlands'
+      postcode 'B1 3GJ'
     end
 
     trait :regent_street_108 do

--- a/spec/support/landing_folder_support/file_objects/et1_txt_file.rb
+++ b/spec/support/landing_folder_support/file_objects/et1_txt_file.rb
@@ -10,6 +10,14 @@ module EtApi
           self.contents = tempfile.readlines("\r\n").map { |l| l.gsub(/\r\n\z/, '') }
         end
 
+        def has_correct_encoding?(errors: [], indent: 1)
+          expect(tempfile.path).to have_file_encoding('unknown-8bit').or have_file_encoding('us-ascii')
+          true
+        rescue RSpec::Expectations::ExpectationNotMetError => err
+          errors.concat(err.message.lines.map { |l| "#{'  ' * indent}#{l.gsub(/\n\z/, '')}" })
+          false
+        end
+
         def has_correct_file_structure?(errors: []) # rubocop:disable Naming/PredicateName
           has_header_section?(errors: errors)
           has_claimant_section?(errors: errors)

--- a/spec/support/landing_folder_support/file_objects/et1a_txt_file.rb
+++ b/spec/support/landing_folder_support/file_objects/et1a_txt_file.rb
@@ -21,6 +21,14 @@ module EtApi
           cloned_tempfile.rewind
         end
 
+        def has_correct_encoding?(errors: [], indent: 1)
+          expect(tempfile.path).to have_file_encoding('unknown-8bit').or have_file_encoding('us-ascii')
+          true
+        rescue RSpec::Expectations::ExpectationNotMetError => err
+          errors.concat(err.message.lines.map { |l| "#{'  ' * indent}#{l.gsub(/\n\z/, '')}" })
+          false
+        end
+
         def has_correct_file_structure?(errors: []) # rubocop:disable Naming/PredicateName
           has_header_section?(errors: errors)
           has_claimants_sections?(errors: errors)

--- a/spec/support/landing_folder_support/file_objects/et3_txt_file.rb
+++ b/spec/support/landing_folder_support/file_objects/et3_txt_file.rb
@@ -12,6 +12,14 @@ module EtApi
           self.contents = tempfile.readlines("\r\n").map { |l| l.gsub(/\r\n\z/, '') }
         end
 
+        def has_correct_encoding?(errors: [], indent: 1)
+          expect(tempfile.path).to have_file_encoding('unknown-8bit').or have_file_encoding('us-ascii')
+          true
+        rescue RSpec::Expectations::ExpectationNotMetError => err
+          errors.concat(err.message.lines.map { |l| "#{'  ' * indent}#{l.gsub(/\n\z/, '')}" })
+          false
+        end
+
         def has_correct_file_structure?(errors: []) # rubocop:disable Naming/PredicateName
           has_header_section?(errors: errors)
           has_intro_section?(errors: errors)

--- a/spec/support/matchers/have_file_encoding.rb
+++ b/spec/support/matchers/have_file_encoding.rb
@@ -1,0 +1,13 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define(:have_file_encoding) do |expected|
+  actual_file_encoding = nil
+  match do |actual|
+    actual_file_encoding = `file --mime-encoding #{actual}`.match(/: (\S*)/)[1]
+    actual_file_encoding == expected
+  end
+
+  failure_message do |actual|
+    "expected that #{actual} is a encoded with #{expected} but it was encoded with #{actual_file_encoding}"
+  end
+end


### PR DESCRIPTION
This PR fixes an issue where if the user enters in any UTF8 characters (such as a posh apostrophe - in this address - St John’s Lane ) - the resulting files would end up as UTF8 and ETHOS importing stopped completely.