### PR TITLE
Update Minio

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     networks:
       - api
   minio:
-    image: minio/minio:RELEASE.2018-08-25T01-56-38Z
+    image: minio/minio
     volumes:
       - minio_data:/export
     ports:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     networks:
       - api
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2018-10-06T00-15-16Z
     volumes:
       - minio_data:/export
     ports:


### PR DESCRIPTION
We were using minio locked to August, this PR updates to use the latest version (6th October).

I am going to add minio to ET3 to mock S3 shortly. As we want to use one version of tools across all our services, this presents an opportunity to update the version of minio we use.