### PR TITLE
Fix bug RST-1477

### DIFF
--- a/app/services/claim_file_builder/render_to_file.rb
+++ b/app/services/claim_file_builder/render_to_file.rb
@@ -5,7 +5,7 @@ module ClaimFileBuilder
     class_methods do
 
       def render_to_file(object:)
-        Tempfile.new(encoding: 'windows-1252').tap do |file|
+        Tempfile.new(encoding: 'windows-1252', invalid: :replace, undef: :replace, replace: '').tap do |file|
           file.write with_windows_lf(render(object))
           file.rewind
         end

--- a/spec/factories/json/json_claimant_factory.rb
+++ b/spec/factories/json/json_claimant_factory.rb
@@ -9,6 +9,13 @@ FactoryBot.define do
       last_name "O'Malley"
     end
 
+    trait :mr_na_unicode do
+      mr_first_last
+      first_name 'n/a'
+      last_name "Unicode"
+      mobile_number "\u202d01234 777666\u202d"
+    end
+
     trait :mr_first_last do
       title 'Mr'
       first_name 'First'

--- a/spec/factories/json/json_respondent_factory.rb
+++ b/spec/factories/json/json_respondent_factory.rb
@@ -32,5 +32,11 @@ FactoryBot.define do
       full
       name "n/a O'Leary"
     end
+
+    trait :mr_na_unicode do
+      full
+      name "n/a Unicode"
+      address_telephone_number "\u202d01234 777666\u202d"
+    end
   end
 end

--- a/spec/services/claim_file_builder/build_claim_text_file_spec.rb
+++ b/spec/services/claim_file_builder/build_claim_text_file_spec.rb
@@ -27,5 +27,29 @@ RSpec.describe ClaimFileBuilder::BuildClaimTextFile do
         expect(uploaded_file.file.download).to be_valid_et1_claim_text
       end
     end
+
+    context 'with a single claimant, respondent and representative with unicode data present' do
+      let(:claim) { create(:claim, :example_data, primary_claimant: build(:claimant, :example_data, mobile_number: "\u202d01234 098765\u202d")) }
+
+      it 'stores an ET1 txt file with the correct filename' do
+        # Act
+        builder.call(claim)
+
+        # Assert
+        expect(claim.uploaded_files).to include an_object_having_attributes filename: 'et1_First_Last.txt',
+                                                                            file: be_a_stored_file
+
+      end
+
+      it 'stores an ET1 txt file with the correct contents' do
+        # Act
+        builder.call(claim)
+        claim.save
+
+        # Assert
+        uploaded_file = claim.uploaded_files.where(filename: 'et1_First_Last.txt').first
+        expect(uploaded_file.file.download).to be_valid_et1_claim_text
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix bug RST-1477 Some unicode characters could not be converted into windows encoding

This PR changes the render method used for all file output to ATOS - specifying that any unknown characters will get removed rather than raising an exception