### PR TITLE
RST-1483: Migrate employment_details Default and Existing Values

### DIFF
--- a/db/migrate/20181031123357_fix_default_employment_details.rb
+++ b/db/migrate/20181031123357_fix_default_employment_details.rb
@@ -1,0 +1,9 @@
+class FixDefaultEmploymentDetails < ActiveRecord::Migration[5.2]
+  def change
+    change_column :claims, :employment_details, :jsonb, default: {}, null: false
+  end
+
+  def down
+    change_column :claims, :employment_details, :jsonb, default: "{}", null: false
+  end
+end

--- a/db/migrate/20181031123357_fix_default_employment_details.rb
+++ b/db/migrate/20181031123357_fix_default_employment_details.rb
@@ -1,5 +1,5 @@
 class FixDefaultEmploymentDetails < ActiveRecord::Migration[5.2]
-  def change
+  def up
     change_column :claims, :employment_details, :jsonb, default: {}, null: false
   end
 

--- a/db/migrate/20181031123747_update_default_employment_details.rb
+++ b/db/migrate/20181031123747_update_default_employment_details.rb
@@ -1,0 +1,7 @@
+class UpdateDefaultEmploymentDetails < ActiveRecord::Migration[5.2]
+  def up
+    Claim.where(employment_details: "{}").update_all(employment_details: {})
+  end
+
+  def down; end
+end

--- a/db/migrate/20181031123747_update_default_employment_details.rb
+++ b/db/migrate/20181031123747_update_default_employment_details.rb
@@ -1,4 +1,8 @@
 class UpdateDefaultEmploymentDetails < ActiveRecord::Migration[5.2]
+  class Claim < ActiveRecord::Base
+    self.table_name = :claims
+  end
+
   def up
     Claim.where(employment_details: "{}").update_all(employment_details: {})
   end


### PR DESCRIPTION
There is an error in the default value for the `employment_details` section of a `Claim`. The default value is currently `"{}"` which is a string of empty hash notation as opposed to an empty hash itself. This PR sets the default value to `{}` from this point onwards and also migrates existing instances of `"{}"` to `{}`.

This then enables an ActiveRecord query to be run which checks if the `employment_details` section of a `Claim` is `.empty?`, which will be used to provide a data extraction for RST-1483.