### PR TITLE
RST-1674 - Case insensitive filenames

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -31,18 +31,22 @@ class Claim < ApplicationRecord
   #
   # @return [UploadedFile, nil] The pdf file if it exists
   def pdf_file
-    uploaded_files.detect { |f| f.filename.ends_with?('.pdf') }
+    uploaded_files.detect { |f| f.filename.downcase.ends_with?('.pdf') }
   end
 
   # A claim can only have one csv file - this is it
   #
   # @return [UploadedFile, nil] The csv file if it exists
   def claimants_csv_file
-    uploaded_files.detect { |f| f.filename.ends_with?('.csv') }
+    uploaded_files.detect { |f| f.filename.downcase.ends_with?('.csv') }
   end
 
   def multiple_claimants?
     secondary_claimants.length.positive?
+  end
+
+  def rtf_file
+    uploaded_files.detect { |f| f.filename.downcase.ends_with?('.rtf') }
   end
 
   private

--- a/app/services/claim_claimants_file_importer_service.rb
+++ b/app/services/claim_claimants_file_importer_service.rb
@@ -18,7 +18,7 @@ class ClaimClaimantsFileImporterService
   private
 
   def csv_file
-    claim.uploaded_files.detect { |f| f.filename.end_with?('.csv') }
+    claim.claimants_csv_file
   end
 
   def import_claimants(uploaded_file:)

--- a/spec/factories/json/json_claim_factory.rb
+++ b/spec/factories/json/json_claim_factory.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
       number_of_secondary_respondents { 1 }
       number_of_representatives { 1 }
       has_pdf_file { true }
-      has_csv_file { false }
-      has_rtf_file { false }
+      csv_file_trait { nil }
+      rtf_file_trait { false }
       case_type { 'Single' }
       sequence :reference do |idx|
         "#{2220000000 + idx}00"
@@ -28,11 +28,20 @@ FactoryBot.define do
 
     trait :with_csv do
       case_type { 'Multiple' }
-      has_csv_file { true }
+      csv_file_trait { :simple_user_with_csv_group_claims }
+    end
+
+    trait :with_csv_uppercased do
+      case_type { 'Multiple' }
+      csv_file_trait { :simple_user_with_csv_group_claims_uppercased }
     end
 
     trait :with_rtf do
-      has_rtf_file { true }
+      rtf_file_trait { :simple_user_with_rtf }
+    end
+
+    trait :with_rtf_uppercased do
+      rtf_file_trait { :simple_user_with_rtf_uppercased }
     end
 
     after(:build) do |doc, evaluator|
@@ -45,8 +54,8 @@ FactoryBot.define do
 
         doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildPrimaryRepresentative', data: build(:json_representative_data, *primary_representative_traits)) if number_of_representatives > 0
         doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildPdfFile', data: build(:json_file_data, :et1_first_last_pdf)) if has_pdf_file
-        doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildClaimantsFile', data: build(:json_file_data, :simple_user_with_csv_group_claims)) if has_csv_file
-        doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildClaimDetailsFile', data: build(:json_file_data, :simple_user_with_rtf)) if has_rtf_file
+        doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildClaimantsFile', data: build(:json_file_data, csv_file_trait)) if csv_file_trait
+        doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildClaimDetailsFile', data: build(:json_file_data, rtf_file_trait)) if rtf_file_trait
       end
     end
 

--- a/spec/factories/json/json_file_factory.rb
+++ b/spec/factories/json/json_file_factory.rb
@@ -24,8 +24,28 @@ FactoryBot.define do
       end
     end
 
+    trait :simple_user_with_csv_group_claims_uppercased do
+      filename { 'simple_user_with_csv_group_claims.CSV' }
+      checksum { '7ac66d9f4af3b498e4cf7b9430974618' }
+      data_from_key { nil }
+      after(:build) do |obj, _e|
+        uploaded_file = create(:uploaded_file, :example_claim_claimants_csv)
+        obj.data_url = uploaded_file.file.blob.service_url
+      end
+    end
+
     trait :simple_user_with_rtf do
       filename { 'simple_user_with_rtf.rtf' }
+      checksum { 'e69a0344620b5040b7d0d1595b9c7726' }
+      data_from_key { nil }
+      after(:build) do |obj, _e|
+        uploaded_file = create(:uploaded_file, :example_claim_rtf)
+        obj.data_url = uploaded_file.file.blob.service_url
+      end
+    end
+
+    trait :simple_user_with_rtf_uppercased do
+      filename { 'simple_user_with_rtf.RTF' }
       checksum { 'e69a0344620b5040b7d0d1595b9c7726' }
       data_from_key { nil }
       after(:build) do |obj, _e|

--- a/spec/requests/v2/create_claim_spec.rb
+++ b/spec/requests/v2/create_claim_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe 'Create Claim Request', type: :request do
         # Assert - look for the correct file in the landing folder - will be async
         Dir.mktmpdir do |dir|
           staging_folder.extract(output_filename_rtf, to: File.join(dir, output_filename_rtf))
-          input_rtf_file_full_path = File.absolute_path(File.join('..', '..', '..', 'fixtures', input_rtf_file), __FILE__)
+          input_rtf_file_full_path = File.absolute_path(File.join('..', '..', '..', 'fixtures', input_rtf_file.downcase), __FILE__)
           expect(File.join(dir, output_filename_rtf)).to be_a_file_copy_of(input_rtf_file_full_path)
         end
       end

--- a/spec/requests/v2/create_claim_spec.rb
+++ b/spec/requests/v2/create_claim_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe 'Create Claim Request', type: :request do
         Dir.mktmpdir do |dir|
           staging_folder.extract(output_filename_additional_claimants_csv, to: File.join(dir, output_filename_additional_claimants_csv))
           input_csv_file_full_path = File.absolute_path(File.join('..', '..', '..', 'fixtures', input_csv_file), __FILE__)
-          expect(File.join(dir, output_filename_additional_claimants_csv)).to be_a_file_copy_of(input_csv_file_full_path)
+          expect(File.join(dir, output_filename_additional_claimants_csv)).to be_a_file_copy_of(input_csv_file_full_path.downcase)
         end
       end
     end

--- a/spec/requests/v2/create_claim_spec.rb
+++ b/spec/requests/v2/create_claim_spec.rb
@@ -345,6 +345,20 @@ RSpec.describe 'Create Claim Request', type: :request do
       include_examples 'a claim with a csv file'
     end
 
+    context 'with json for multiple claimants, single respondent and no representative - with csv file uploaded but uppercased filename' do
+      include_context 'with fake sidekiq'
+      include_context 'with setup for claims',
+        json_factory: -> { FactoryBot.build(:json_build_claim_commands, :with_csv_uppercased, number_of_secondary_respondents: 0, number_of_representatives: 0) }
+      include_examples 'any claim variation'
+      include_examples 'a claim exported to primary ATOS'
+      include_examples 'a claim with provided reference number'
+      include_examples 'a claim with multiple claimants'
+      include_examples 'a claim with multiple claimants from csv'
+      include_examples 'a claim with single respondent'
+      include_examples 'a claim with no representatives'
+      include_examples 'a claim with a csv file'
+    end
+
     context 'with json for single claimant, respondent and representative' do
       include_context 'with fake sidekiq'
       include_context 'with setup for claims',
@@ -513,6 +527,20 @@ RSpec.describe 'Create Claim Request', type: :request do
       include_context 'with fake sidekiq'
       include_context 'with setup for claims',
         json_factory: -> { FactoryBot.build(:json_build_claim_commands, :with_rtf, number_of_secondary_claimants: 0, number_of_secondary_respondents: 0, number_of_representatives: 1) }
+
+      include_examples 'any claim variation'
+      include_examples 'a claim exported to primary ATOS'
+      include_examples 'a claim with provided reference number'
+      include_examples 'a claim with single claimant'
+      include_examples 'a claim with single respondent'
+      include_examples 'a claim with a representative'
+      include_examples 'a claim with an rtf file'
+    end
+
+    context 'with json for single claimant, single respondent and representative - with rtf file uploaded with uppercased extension' do
+      include_context 'with fake sidekiq'
+      include_context 'with setup for claims',
+        json_factory: -> { FactoryBot.build(:json_build_claim_commands, :with_rtf_uppercased, number_of_secondary_claimants: 0, number_of_secondary_respondents: 0, number_of_representatives: 1) }
 
       include_examples 'any claim variation'
       include_examples 'a claim exported to primary ATOS'

--- a/vendor/gems/et_atos_export/app/event_handlers/et_atos_export/export_claim_handler.rb
+++ b/vendor/gems/et_atos_export/app/event_handlers/et_atos_export/export_claim_handler.rb
@@ -19,7 +19,7 @@ module EtAtosExport
     end
 
     def rename_rtf_file(claim:)
-      file = claim.uploaded_files.detect { |f| f.filename.ends_with?('.rtf') }
+      file = claim.rtf_file
       return if file.nil?
       claimant = claim.primary_claimant
       file.filename = "et1_attachment_#{claimant[:first_name].tr(' ', '_')}_#{claimant[:last_name]}.rtf"


### PR DESCRIPTION
This PR fixes a bug raised in RST-1674 where if a user were to send a filename with the file extension uppercased, the system would not find the RTF or CSV file in ET1.

This is not an issue with ET3 as the file transfer mechanism is different and that doesnt send the uppercased extension