### PR TITLE
RST-1711 API - Live Issue - CSV file was failing

### DIFF
--- a/app/services/claim_claimants_file_importer_service.rb
+++ b/app/services/claim_claimants_file_importer_service.rb
@@ -34,7 +34,7 @@ class ClaimClaimantsFileImporterService
   def force_utf8_file(file)
     block_size = 1024
     tempfile = Tempfile.new
-    while true do
+    loop do
       chunk = file.read(block_size)
       break if chunk.nil?
       tempfile.write chunk.encode('utf-8', invalid: :replace, undef: :replace)

--- a/app/services/claim_claimants_file_importer_service.rb
+++ b/app/services/claim_claimants_file_importer_service.rb
@@ -24,10 +24,22 @@ class ClaimClaimantsFileImporterService
   def import_claimants(uploaded_file:)
     tempfile = Tempfile.new
     uploaded_file.download_blob_to(tempfile.path)
+    utf8_tempfile = force_utf8_file(tempfile)
     ActiveRecord::Base.transaction do
-      import_claimants_from_file(file: tempfile.path)
+      import_claimants_from_file(file: utf8_tempfile.path)
       claim.save! if autosave
     end
+  end
+
+  def force_utf8_file(file)
+    block_size = 1024
+    tempfile = Tempfile.new
+    while true do
+      chunk = file.read(block_size)
+      break if chunk.nil?
+      tempfile.write chunk.encode('utf-8', invalid: :replace, undef: :replace)
+    end
+    tempfile.tap(&:close)
   end
 
   def import_claimants_from_file(file:)

--- a/spec/factories/uploaded_file_factory.rb
+++ b/spec/factories/uploaded_file_factory.rb
@@ -40,6 +40,14 @@ FactoryBot.define do
       end
     end
 
+    trait :example_claim_claimants_csv_bad_encoding do
+      filename { 'et1a_first_last.csv' }
+      checksum { 'ee2714b8b731a8c1e95dffaa33f89728' }
+      after(:build) do |uploaded_file, _evaluator|
+        uploaded_file.file.attach(Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'simple_user_with_csv_group_claims_bad_encoding.csv'), 'text/csv'))
+      end
+    end
+
     trait :example_response_text do
       filename { 'et3_atos_export.txt' }
       checksum { 'ee2714b8b731a8c1e95dffaa33f89728' }

--- a/spec/fixtures/simple_user_with_csv_group_claims_bad_encoding.csv
+++ b/spec/fixtures/simple_user_with_csv_group_claims_bad_encoding.csv
@@ -1,0 +1,4 @@
+Title,First name,Last name,Date of birth,Building number or name,Street,Town/city,County,Postcode
+Mrs ,Tamara,D’Arcy,01/01/2000,71088,Nova Loaf,Liverpool ,Merseyside,L10 3KPL
+Miss,Diana ,O’Neill ,01/01/2000,66262 ,Feeney Station ,Eastbourne,East Sussex,DE21 4LR 
+Miss,Mariana,O'Gorman,01/01/2000,819 ,Mitchell Glen,Windsor,Berkshire,UH2 4NA

--- a/spec/support/helpers/normalize_csv_data_helper.rb
+++ b/spec/support/helpers/normalize_csv_data_helper.rb
@@ -3,8 +3,19 @@ module EtApi
   module Test
     module NormalizeCsvDataHelper
       def normalize_claimants_from_file(file: File.absolute_path(File.join('../../fixtures/simple_user_with_csv_group_claims.csv'), __dir__))
+
+        block_size = 1024
+        tempfile = Tempfile.new
+        input_file = File.open(file, 'r')
+        while true do
+          chunk = input_file.read(block_size)
+          break if chunk.nil?
+          tempfile.write chunk.encode('utf-8', invalid: :replace, undef: :replace)
+        end
+        tempfile.tap(&:close)
+
         claimants_array = []
-        CSV.foreach file, headers: true do |row|
+        CSV.foreach tempfile, headers: true do |row|
           claimants_array << {
             title: row['Title'],
             first_name: row['First name'].try(:downcase),


### PR DESCRIPTION
RST-1711 API - Live Issue - CSV file was failing due to invalid utf8 content - code will now convert to utf8, ignoring any weird characters that it cannot convert