### PR TITLE
Rst 1717 et3 ai endpoint

### DIFF
--- a/app/services/direct_upload_into_collection_service.rb
+++ b/app/services/direct_upload_into_collection_service.rb
@@ -2,6 +2,11 @@ class DirectUploadIntoCollectionService
   def initialize(collection:, filename:)
     self.collection = collection
     self.filename = filename
+    if ActiveStorage::Blob.service.is_a?(ActiveStorage::Service::S3Service)
+      self.adapter = Amazon.new(filename)
+    else
+      self.adapter = Azure.new(filename)
+    end
   end
 
   def import(value)
@@ -20,7 +25,7 @@ class DirectUploadIntoCollectionService
     end
   end
 
-  attr_accessor :collection, :filename
+  attr_accessor :collection, :filename, :adapter
 
   def find_file
     collection.detect { |file| file.filename == filename }
@@ -42,25 +47,65 @@ class DirectUploadIntoCollectionService
     collection.delete(existing)
   end
 
-  def blob_attributes_for(value)
-    source_object = s3_client.get_object(bucket: direct_upload_bucket, key: value)
-    { filename: filename,
-      byte_size: source_object.content_length,
-      checksum: 'doesntseemtomatter',
-      content_type: 'application/rtf',
-      metadata: {} }
+  delegate :blob_attributes_for, :import_into_blob, to: :adapter
+
+  class Amazon
+    def initialize(filename)
+      self.filename = filename
+    end
+
+    def blob_attributes_for(value)
+      source_object = s3_client.get_object(bucket: direct_upload_bucket, key: value)
+      { filename: filename,
+        byte_size: source_object.content_length,
+        checksum: 'doesntseemtomatter',
+        content_type: 'application/rtf',
+        metadata: {} }
+    end
+
+    def import_into_blob(blob, value)
+      object = blob.service.bucket.object(blob.key)
+      object.copy_from(bucket: direct_upload_bucket, key: value)
+    end
+
+    def direct_upload_bucket
+      @direct_upload_bucket ||= Rails.configuration.s3_direct_upload_bucket
+    end
+
+    def s3_client
+      @s3_client ||= ActiveStorage::Blob.service.client.client
+    end
+
+    private
+
+    attr_accessor :filename
+
   end
 
-  def import_into_blob(blob, value)
-    object = blob.service.bucket.object(blob.key)
-    object.copy_from(bucket: direct_upload_bucket, key: value)
-  end
+  class Azure
+    def initialize(filename)
+      self.filename = filename
+    end
 
-  def direct_upload_bucket
-    @direct_upload_bucket ||= Rails.configuration.s3_direct_upload_bucket
-  end
+    def blob_attributes_for(value)
+      props = azure_direct_service.blobs.get_blob_properties(azure_direct_service.container, value)
+      { filename: filename,
+        byte_size: props.properties[:content_length],
+        checksum: 'doesntseemtomatter',
+        content_type: 'application/rtf',
+        metadata: {} }
+    end
 
-  def s3_client
-    @s3_client ||= ActiveStorage::Blob.service.client.client
+    def import_into_blob(blob, value)
+      azure_direct_service.blobs.copy_blob(blob.service.container, blob.key, azure_direct_service.container, value)
+    end
+
+    private
+
+    def azure_direct_service
+      @azure_direct_service ||= ActiveStorage::Service.configure :azure_direct_upload, Rails.configuration.active_storage.service_configurations
+    end
+
+    attr_accessor :filename
   end
 end

--- a/app/services/direct_upload_into_collection_service.rb
+++ b/app/services/direct_upload_into_collection_service.rb
@@ -2,10 +2,10 @@ class DirectUploadIntoCollectionService
   def initialize(collection:, filename:)
     self.collection = collection
     self.filename = filename
-    if ActiveStorage::Blob.service.is_a?(ActiveStorage::Service::S3Service)
-      self.adapter = Amazon.new(filename)
-    else
+    if ActiveStorage::Blob.service.class.name =~ /Azure/
       self.adapter = Azure.new(filename)
+    else
+      self.adapter = Amazon.new(filename)
     end
   end
 

--- a/spec/documentation/build_blob_amazon_spec.rb
+++ b/spec/documentation/build_blob_amazon_spec.rb
@@ -1,20 +1,6 @@
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 resource 'Blob Resource (Amazon mode)' do
-  shared_context 'with cloud provider switching' do |cloud_provider:|
-    around do |example|
-      original = Rails.configuration.active_storage.service
-      begin
-        Rails.configuration.active_storage.service = cloud_provider
-        ActiveSupport.run_load_hooks(:active_storage_blob, ActiveStorage::Blob)
-        example.run
-      ensure
-        Rails.configuration.active_storage.service = original
-        ActiveSupport.run_load_hooks(:active_storage_blob, ActiveStorage::Blob)
-      end
-    end
-  end
-
   explanation "Signed Blob resource - amazon mode"
 
   header "Content-Type", "application/json"

--- a/spec/documentation/build_blob_azure_spec.rb
+++ b/spec/documentation/build_blob_azure_spec.rb
@@ -1,20 +1,6 @@
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 resource 'Blob Resource (Azure mode)' do
-  shared_context 'with cloud provider switching' do |cloud_provider:|
-    around do |example|
-      original = Rails.configuration.active_storage.service
-      begin
-        Rails.configuration.active_storage.service = cloud_provider
-        ActiveSupport.run_load_hooks(:active_storage_blob, ActiveStorage::Blob)
-        example.run
-      ensure
-        Rails.configuration.active_storage.service = original
-        ActiveSupport.run_load_hooks(:active_storage_blob, ActiveStorage::Blob)
-      end
-    end
-  end
-
   explanation "Signed Blob resource - azure mode"
 
   header "Content-Type", "application/json"

--- a/spec/documentation/create_signed_s3_url_spec.rb
+++ b/spec/documentation/create_signed_s3_url_spec.rb
@@ -6,6 +6,7 @@ resource 'Signed S3 Resource' do
   header "Content-Type", "application/json"
   header "Accept", "application/json"
 
+  # @TODO RST-1676 Remove amazon code
   post '/api/v2/s3/create_signed_url' do
 
     parameter :uuid, "A unique ID produced by the client to refer to this command", type: :string, with_example: true, in: :body
@@ -13,7 +14,7 @@ resource 'Signed S3 Resource' do
     parameter :command, type: :string, enum: ['SerialSequence'], with_example: true, in: :body
 
     context "200" do
-
+      include_context 'with cloud provider switching', cloud_provider: :amazon
       example 'Create a signed s3 object suitable for use in a HTML form for use with direct upload' do
         request =  build(:json_create_signed_s3_url_command).as_json
 

--- a/spec/factories/json/json_response_factory.rb
+++ b/spec/factories/json/json_response_factory.rb
@@ -127,19 +127,30 @@ FactoryBot.define do
     additional_information_key do
       next if rtf_file_path.nil?
 
-      config = {
-        region: ENV.fetch('AWS_REGION', 'us-east-1'),
-        access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID', 'accessKey1'),
-        secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY', 'verySecretKey1'),
-        endpoint: ENV.fetch('AWS_ENDPOINT', 'http://localhost:9000/'),
-        force_path_style: ENV.fetch('AWS_S3_FORCE_PATH_STYLE', 'true') == 'true'
-      }
-      s3 = Aws::S3::Client.new(config)
+      # @TODO RST-1676 Remove all amazon code
+      if ActiveStorage::Blob.service.is_a?(ActiveStorage::Service::AzureStorageService)
+        blob = ActiveStorage::Blob.new filename: File.basename(rtf_file_path)
+        blob.service = ActiveStorage::Service.configure :azure_direct_upload, Rails.configuration.active_storage.service_configurations
+        file = File.open(rtf_file_path, 'r')
+        blob.upload(file)
+        file.close
+        blob.save!
+        blob.key
+      else
+        config = {
+          region: ENV.fetch('AWS_REGION', 'us-east-1'),
+          access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID', 'accessKey1'),
+          secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY', 'verySecretKey1'),
+          endpoint: ENV.fetch('AWS_ENDPOINT', 'http://localhost:9000/'),
+          force_path_style: ENV.fetch('AWS_S3_FORCE_PATH_STYLE', 'true') == 'true'
+        }
+        s3 = Aws::S3::Client.new(config)
 
-      bucket = Aws::S3::Bucket.new(client: s3, name: Rails.configuration.s3_direct_upload_bucket)
-      obj = bucket.object(SecureRandom.uuid)
-      obj.put(body: File.read(rtf_file_path), content_type: 'application/rtf')
-      obj.key
+        bucket = Aws::S3::Bucket.new(client: s3, name: Rails.configuration.s3_direct_upload_bucket)
+        obj = bucket.object(SecureRandom.uuid)
+        obj.put(body: File.read(rtf_file_path), content_type: 'application/rtf')
+        obj.key
+      end
     end
 
     trait :with_rtf do

--- a/spec/factories/json/json_response_factory.rb
+++ b/spec/factories/json/json_response_factory.rb
@@ -128,7 +128,7 @@ FactoryBot.define do
       next if rtf_file_path.nil?
 
       # @TODO RST-1676 Remove all amazon code
-      if ActiveStorage::Blob.service.is_a?(ActiveStorage::Service::AzureStorageService)
+      if ActiveStorage::Blob.service.class.name =~ /Azure/
         blob = ActiveStorage::Blob.new filename: File.basename(rtf_file_path)
         blob.service = ActiveStorage::Service.configure :azure_direct_upload, Rails.configuration.active_storage.service_configurations
         file = File.open(rtf_file_path, 'r')

--- a/spec/models/exported_file_spec.rb
+++ b/spec/models/exported_file_spec.rb
@@ -14,21 +14,22 @@ RSpec.describe ExportedFile, type: :model do
   end
 
   describe '#url' do
-    around do |example|
-      old_value = ActiveStorage::Current.host
-      begin
-        ActiveStorage::Current.host = 'http://example.com'
-        example.call
-        ActiveStorage::Current.host = old_value
-      ensure
-        ActiveStorage::Current.host = old_value
+    context 'using amazon cloud provider' do
+      include_context 'with cloud provider switching', cloud_provider: :amazon
+      it 'returns a minio test server url as we are in test mode' do
+        exported_file.file = fixture_file
+
+        expect(exported_file.url).to start_with(ActiveStorage::Blob.service.bucket.url)
       end
     end
 
-    it 'returns a minio test server url as we are in test mode' do
-      exported_file.file = fixture_file
+    context 'using azure cloud provider' do
+      include_context 'with cloud provider switching', cloud_provider: :azure
+      it 'returns an azurite test server url as we are in test mode' do
+        exported_file.file = fixture_file
 
-      expect(exported_file.url).to start_with(ActiveStorage::Blob.service.bucket.url)
+        expect(exported_file.url).to start_with("#{ActiveStorage::Blob.service.blobs.generate_uri}/#{ActiveStorage::Blob.service.container}")
+      end
     end
   end
 

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -5,33 +5,16 @@ require 'rails_helper'
 RSpec.describe Response, type: :model do
   subject(:response) { described_class.new }
 
-  describe '#additional_information_url=' do
-    let(:rtf_file_path) { Rails.root.join('spec', 'fixtures', 'example.rtf').to_s }
-    # The json_response_data factory is being used just to generate a remote file - nothing else - saves duplicating that code
-    let(:remote_key) do
-      FactoryBot.build(:json_response_data, :with_rtf, rtf_file_path: rtf_file_path).additional_information_key
-    end
+  describe '#additional_information_key=' do
+    context 'in amazon mode' do
+      include_context 'with cloud provider switching', cloud_provider: :amazon
+      let(:rtf_file_path) { Rails.root.join('spec', 'fixtures', 'example.rtf').to_s }
+      # The json_response_data factory is being used just to generate a remote file - nothing else - saves duplicating that code
+      let(:remote_key) do
+        FactoryBot.build(:json_response_data, :with_rtf, rtf_file_path: rtf_file_path).additional_information_key
+      end
 
-    it 'imports a remote file into a new imported file named as the rtf file if it doesnt already exist' do
-      # Act - Assign the remote url
-      response.additional_information_key = remote_key
-
-      # Assert - ensure an uploaded file has been built
-      expect(response.uploaded_files.detect { |f| f.filename == 'additional_information.rtf' }.try(:file)).to be_a_stored_file_with_contents(File.read(rtf_file_path))
-    end
-
-    it 'does nothing if the new value is nil and the rtf file doesnt already exist' do
-      # Act - Assign the remote url
-      response.additional_information_key = nil
-
-      # Assert - ensure an uploaded file has not been built
-      expect(response.uploaded_files.length).to be 0
-    end
-
-    context 'with existing file' do
-      subject(:response) { build(:response, :with_wrong_input_rtf_file) }
-
-      it 'imports a remote file into an existing imported file if it already exist based on a set filename' do
+      it 'imports a remote file into a new imported file named as the rtf file if it doesnt already exist' do
         # Act - Assign the remote url
         response.additional_information_key = remote_key
 
@@ -39,12 +22,76 @@ RSpec.describe Response, type: :model do
         expect(response.uploaded_files.detect { |f| f.filename == 'additional_information.rtf' }.try(:file)).to be_a_stored_file_with_contents(File.read(rtf_file_path))
       end
 
-      it 'removes an imported file if it already exist based on a set filename and the new value is nil' do
+      it 'does nothing if the new value is nil and the rtf file doesnt already exist' do
         # Act - Assign the remote url
         response.additional_information_key = nil
 
-        # Assert - ensure an uploaded file has been removed
+        # Assert - ensure an uploaded file has not been built
         expect(response.uploaded_files.length).to be 0
+      end
+
+      context 'with existing file' do
+        subject(:response) { build(:response, :with_wrong_input_rtf_file) }
+
+        it 'imports a remote file into an existing imported file if it already exist based on a set filename' do
+          # Act - Assign the remote url
+          response.additional_information_key = remote_key
+
+          # Assert - ensure an uploaded file has been built
+          expect(response.uploaded_files.detect { |f| f.filename == 'additional_information.rtf' }.try(:file)).to be_a_stored_file_with_contents(File.read(rtf_file_path))
+        end
+
+        it 'removes an imported file if it already exist based on a set filename and the new value is nil' do
+          # Act - Assign the remote url
+          response.additional_information_key = nil
+
+          # Assert - ensure an uploaded file has been removed
+          expect(response.uploaded_files.length).to be 0
+        end
+      end
+    end
+    context 'in azure mode' do
+      include_context 'with cloud provider switching', cloud_provider: :azure
+      let(:rtf_file_path) { Rails.root.join('spec', 'fixtures', 'example.rtf').to_s }
+      # The json_response_data factory is being used just to generate a remote file - nothing else - saves duplicating that code
+      let(:remote_key) do
+        FactoryBot.build(:json_response_data, :with_rtf, rtf_file_path: rtf_file_path).additional_information_key
+      end
+
+      it 'imports a remote file into a new imported file named as the rtf file if it doesnt already exist' do
+        # Act - Assign the remote url
+        response.additional_information_key = remote_key
+
+        # Assert - ensure an uploaded file has been built
+        expect(response.uploaded_files.detect { |f| f.filename == 'additional_information.rtf' }.try(:file)).to be_a_stored_file_with_contents(File.read(rtf_file_path))
+      end
+
+      it 'does nothing if the new value is nil and the rtf file doesnt already exist' do
+        # Act - Assign the remote url
+        response.additional_information_key = nil
+
+        # Assert - ensure an uploaded file has not been built
+        expect(response.uploaded_files.length).to be 0
+      end
+
+      context 'with existing file' do
+        subject(:response) { build(:response, :with_wrong_input_rtf_file) }
+
+        it 'imports a remote file into an existing imported file if it already exist based on a set filename' do
+          # Act - Assign the remote url
+          response.additional_information_key = remote_key
+
+          # Assert - ensure an uploaded file has been built
+          expect(response.uploaded_files.detect { |f| f.filename == 'additional_information.rtf' }.try(:file)).to be_a_stored_file_with_contents(File.read(rtf_file_path))
+        end
+
+        it 'removes an imported file if it already exist based on a set filename and the new value is nil' do
+          # Act - Assign the remote url
+          response.additional_information_key = nil
+
+          # Assert - ensure an uploaded file has been removed
+          expect(response.uploaded_files.length).to be 0
+        end
       end
     end
   end

--- a/spec/models/uploaded_file_spec.rb
+++ b/spec/models/uploaded_file_spec.rb
@@ -14,20 +14,22 @@ RSpec.describe UploadedFile, type: :model do
   end
 
   describe '#url' do
-    around do |example|
-      old_value = ActiveStorage::Current.host
-      begin
-        ActiveStorage::Current.host = 'http://example.com'
-        example.call
-        ActiveStorage::Current.host = old_value
-      ensure
-        ActiveStorage::Current.host = old_value
+    context 'using amazon cloud provider' do
+      include_context 'with cloud provider switching', cloud_provider: :amazon
+      it 'returns a minio test server url as we are in test mode' do
+        uploaded_file.file = fixture_file
+
+        expect(uploaded_file.url).to start_with(ActiveStorage::Blob.service.bucket.url)
       end
     end
-    it 'returns a minio server url as we are in test mode' do
-      uploaded_file.file = fixture_file
 
-      expect(uploaded_file.url).to start_with(ActiveStorage::Blob.service.bucket.url)
+    context 'using azure cloud provider' do
+      include_context 'with cloud provider switching', cloud_provider: :azure
+      it 'returns an azurite test server url as we are in test mode' do
+        uploaded_file.file = fixture_file
+
+        expect(uploaded_file.url).to start_with("#{ActiveStorage::Blob.service.blobs.generate_uri}/#{ActiveStorage::Blob.service.container}")
+      end
     end
   end
 

--- a/spec/requests/v2/build_blob_spec.rb
+++ b/spec/requests/v2/build_blob_spec.rb
@@ -3,20 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Build a blob using the configured cloud provider', type: :request do
-  shared_context 'with cloud provider switching' do |cloud_provider:|
-    around do |example|
-      original = Rails.configuration.active_storage.service
-      begin
-        Rails.configuration.active_storage.service = cloud_provider
-        ActiveSupport.run_load_hooks(:active_storage_blob, ActiveStorage::Blob)
-        example.run
-      ensure
-        Rails.configuration.active_storage.service = original
-        ActiveSupport.run_load_hooks(:active_storage_blob, ActiveStorage::Blob)
-      end
-    end
-  end
-
   let(:default_headers) do
     {
       'Accept': 'application/json',

--- a/spec/requests/v2/create_response_spec.rb
+++ b/spec/requests/v2/create_response_spec.rb
@@ -346,8 +346,9 @@ RSpec.describe 'Create Response Request', type: :request do
       include_examples 'email validation using standard template'
     end
 
-    context 'with json for a response with an rtf upload' do
+    context 'with json for a response with an rtf upload in amazon mode' do
       rtf_file_path = Rails.root.join('spec', 'fixtures', 'example.rtf').to_s
+      include_context 'with cloud provider switching', cloud_provider: :amazon
       include_context 'with transactions off for use with other processes'
       include_context 'with fake sidekiq'
       include_context 'with setup for any response',
@@ -368,7 +369,31 @@ RSpec.describe 'Create Response Request', type: :request do
           expect(full_path).to be_a_file_copy_of(rtf_file_path)
         end
       end
-      it 'marks the pdf as having an rtf file attached'
+    end
+
+    context 'with json for a response with an rtf upload in azure mode' do
+      rtf_file_path = Rails.root.join('spec', 'fixtures', 'example.rtf').to_s
+      include_context 'with cloud provider switching', cloud_provider: :azure
+      include_context 'with transactions off for use with other processes'
+      include_context 'with fake sidekiq'
+      include_context 'with setup for any response',
+        json_factory: -> { FactoryBot.build(:json_build_response_commands, :with_rtf, rtf_file_path: rtf_file_path) }
+      include_context 'with background jobs running'
+      include_examples 'any response variation'
+      include_examples 'a response with meta for office 22 bristol'
+      include_examples 'a response exported to primary ATOS'
+      include_examples 'email validation using standard template'
+
+      it 'includes the rtf file in the staging folder' do
+        reference = json_response.dig(:meta, 'BuildResponse', :reference)
+        respondent_name = input_respondent_factory.name
+        output_filename_rtf = "#{reference}_ET3_Attachment_#{respondent_name}.rtf"
+        Dir.mktmpdir do |dir|
+          full_path = File.join(dir, output_filename_rtf)
+          staging_folder.extract(output_filename_rtf, to: full_path)
+          expect(full_path).to be_a_file_copy_of(rtf_file_path)
+        end
+      end
     end
 
     context 'with json for a response with an invalid office code in the case number' do

--- a/spec/requests/v2/create_signed_s3_url_spec.rb
+++ b/spec/requests/v2/create_signed_s3_url_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Create signed S3 url request', type: :request do
+  include_context 'with cloud provider switching', cloud_provider: :amazon
   describe 'POST /api/v2/s3/create_signed_url' do
     let(:default_headers) do
       {

--- a/spec/services/uploaded_file_allocator_service_spec.rb
+++ b/spec/services/uploaded_file_allocator_service_spec.rb
@@ -14,38 +14,98 @@ RSpec.describe UploadedFileAllocatorService do
   end
 
   describe '#allocated_url' do
-    it 'returns the url of the allocated file on s3' do
-      # Arrange - Allocate a file
-      service.allocate('test.pdf', into: response)
+    context 'using s3 storage' do
+      include_context 'with cloud provider switching', cloud_provider: :amazon
+      it 'returns the url of the allocated file on s3' do
+        # Arrange - Allocate a file
+        service.allocate('test.pdf', into: response)
 
-      # Act - get the url
-      result = service.allocated_url
+        # Act - get the url
+        result = service.allocated_url
 
-      # Assert - make sure it is a url
-      expect(result).to be_a_valid_url
+        # Assert - make sure it is a url
+        expect(result).to be_a_valid_url
+      end
+
+      it 'returns a url that will 404 if requested' do
+        # Arrange - Allocate a file
+        service.allocate('test.pdf', into: response)
+
+        # Act - get from the url
+        result = HTTParty.get service.allocated_url
+
+        # Assert - make sure the response is a 404 when requested
+        expect(result.code).to be 404
+      end
+
+      it 'returns a url which will expire in 1 hour' do
+        # Arrange - Allocate a file
+        service.allocate('test.pdf', into: response)
+
+        # Act - get the url
+        result = service.allocated_url
+
+        # Assert - make sure it is a url
+        query = Rack::Utils.parse_nested_query(URI.parse(result).query)
+        expect(query).to include 'X-Amz-Expires' => '3600'
+      end
+
+      it 'returns a minio test server url as we are in test mode' do
+        # Arrange - Allocate a file
+        service.allocate('test.pdf', into: response)
+
+        # Act - get the url
+        result = service.allocated_url
+
+        expect(result).to start_with(ActiveStorage::Blob.service.bucket.url)
+      end
     end
+    context 'using azure storage' do
+      include_context 'with cloud provider switching', cloud_provider: :azure
+      it 'returns the url of the allocated file on azure' do
+        # Arrange - Allocate a file
+        service.allocate('test.pdf', into: response)
 
-    it 'returns a url that will 404 if requested' do
-      # Arrange - Allocate a file
-      service.allocate('test.pdf', into: response)
+        # Act - get the url
+        result = service.allocated_url
 
-      # Act - get from the url
-      result = HTTParty.get service.allocated_url
+        # Assert - make sure it is a url
+        expect(result).to be_a_valid_url
+      end
 
-      # Assert - make sure the response is a 404 when requested
-      expect(result.code).to be 404
-    end
+      it 'returns a url that will 404 if requested' do
+        # Arrange - Allocate a file
+        service.allocate('test.pdf', into: response)
 
-    it 'returns a url which will expire in 1 hour' do
-      # Arrange - Allocate a file
-      service.allocate('test.pdf', into: response)
+        # Act - get from the url
+        result = HTTParty.get service.allocated_url
 
-      # Act - get the url
-      result = service.allocated_url
+        # Assert - make sure the response is a 404 when requested
+        expect(result.code).to be 404
+      end
 
-      # Assert - make sure it is a url
-      query = Rack::Utils.parse_nested_query(URI.parse(result).query)
-      expect(query).to include 'X-Amz-Expires' => '3600'
+      it 'returns a url which will expire in 1 hour' do
+        # Arrange - Allocate a file
+        service.allocate('test.pdf', into: response)
+
+        # Act - get the url
+        result = service.allocated_url
+
+        # Assert - make sure it is a url
+        query = Rack::Utils.parse_nested_query(URI.parse(result).query)
+        expiry = Time.zone.parse(query['se']).utc
+        expect(expiry - Time.zone.now.utc).to be_between(3590, 3600)
+      end
+
+      it 'returns an azurite test server url as we are in test mode' do
+        # Arrange - Allocate a file
+        service.allocate('test.pdf', into: response)
+
+        # Act - get the url
+        result = service.allocated_url
+
+        expect(result).to start_with("#{ActiveStorage::Blob.service.blobs.generate_uri}/#{ActiveStorage::Blob.service.container}")
+      end
     end
   end
 end

--- a/spec/support/setup_s3_buckets.rb
+++ b/spec/support/setup_s3_buckets.rb
@@ -1,17 +1,11 @@
 require 'active_storage/service/s3_service'
 RSpec.configure do |c|
   c.before(:suite) do
-    config = {
-      region: ENV.fetch('AWS_REGION', 'us-east-1'),
-      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID', 'accessKey1'),
-      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY', 'verySecretKey1'),
-      endpoint: ENV.fetch('AWS_ENDPOINT', 'http://localhost:9000/'),
-      force_path_style: ENV.fetch('AWS_S3_FORCE_PATH_STYLE', 'true') == 'true'
-    }
-    s3 = Aws::S3::Client.new(config)
-    next unless ActiveStorage::Blob.service.is_a?(ActiveStorage::Service::S3Service)
+    ActiveStorage::Blob.service # Will ensure active storage is configured
+    config = Rails.configuration.active_storage.service_configurations['amazon'].symbolize_keys
+    s3 = Aws::S3::Client.new(config.except(:service, :bucket))
 
-    Aws::S3::Bucket.new(client: s3, name: ActiveStorage::Blob.service.bucket.name).tap do |bucket|
+    Aws::S3::Bucket.new(client: s3, name: config[:bucket]).tap do |bucket|
       bucket.create unless bucket.exists?
       bucket.objects.each(&:delete)
     end

--- a/spec/support/shared_contexts/with_cloud_provider_switching.rb
+++ b/spec/support/shared_contexts/with_cloud_provider_switching.rb
@@ -1,0 +1,13 @@
+shared_context 'with cloud provider switching' do |cloud_provider:|
+  around do |example|
+    original = Rails.configuration.active_storage.service
+    begin
+      Rails.configuration.active_storage.service = cloud_provider
+      ActiveSupport.run_load_hooks(:active_storage_blob, ActiveStorage::Blob)
+      example.run
+    ensure
+      Rails.configuration.active_storage.service = original
+      ActiveSupport.run_load_hooks(:active_storage_blob, ActiveStorage::Blob)
+    end
+  end
+end


### PR DESCRIPTION
This PR allows the et3 submission end point to work in azure mode - so when in azure mode, it gets the source file from azure direct upload location and saves a copy in the azure active storage location ready for use by the rest of the application