### PR TITLE
Trying puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ end
 gem 'rails', '~> 5.2.2'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
-gem 'unicorn'
+
+gem 'puma', '~> 3.12'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,7 @@ GEM
     pg (1.1.3)
     powerpack (0.1.2)
     public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.6)
     rack-protection (2.0.3)
       rack
@@ -379,6 +380,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pdf-forms (~> 1.2)
   pg (>= 0.18, < 2.0)
+  puma (~> 3.12)
   rails (~> 5.2.2)
   rspec-eventually (~> 0.2.2)
   rspec-rails (~> 3.8)
@@ -395,7 +397,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
-  unicorn
   webmock (~> 3.4)
   wisper (= 2.0.0)
 

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec unicorn -p 8080 -c ./config/unicorn.rb
+web: bundle exec puma --port=8080 --config=./config/unicorn.rb
 sidekiq: bundle exec sidekiq

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,14 +21,31 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 3 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
+
+before_fork do
+  puts "Puma master process about to fork. Closing existing Active record connections."
+  ActiveRecord::Base.connection.disconnect!
+  puts "Puma master process about to fork. Closing existing redis connections."
+  Redis.current.disconnect!
+  Redis.current = nil
+end
+
+on_worker_boot do
+  ActiveSupport.on_load(:active_record) do
+    puts "Puma worker booting - establishing Active record connection"
+    ActiveRecord::Base.establish_connection
+    puts "Puma worker booting - establishing redis connection"
+    Redis.current
+  end
+end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,1 +1,0 @@
-worker_processes Integer(ENV.fetch("WEB_CONCURRENCY", 1))

--- a/run.sh
+++ b/run.sh
@@ -20,4 +20,4 @@ supervisord -c /etc/supervisor.conf &
 
 echo "Running app"
 
-bundle exec unicorn -p 8080 -c ./config/unicorn.rb -E production
+bundle exec puma --port=8080 --config=./config/puma.rb --environment=production


### PR DESCRIPTION
This PR configures our web server to use puma instead of unicorn.

This was trialled in the dev environment in order to gain performance improvement figures and it si estimated to be maybe 30% faster.

The main reason for using it is so that when a slow external request in the API (currently only the acas certificate lookup) is in progress - it does not tie up a whole worker - instead just one thread in a worker - hopefully reducing client side timeouts in et1 application