### PR TITLE
RST-1824 - Mailer using file before it was ready

### DIFF
--- a/app/event_handlers/prepare_response_handler.rb
+++ b/app/event_handlers/prepare_response_handler.rb
@@ -3,9 +3,8 @@ class PrepareResponseHandler
     ActiveRecord::Base.transaction do
       ImportUploadedFilesHandler.new.handle(response)
       ResponsePdfFileHandler.new.handle(response)
-      ResponseEmailHandler.new.handle(response)
       response.save if response.changed?
-      EventService.publish('ResponsePrepared', response)
     end
+    EventService.publish('ResponsePrepared', response)
   end
 end

--- a/config/initializers/event_handlers.rb
+++ b/config/initializers/event_handlers.rb
@@ -1,6 +1,7 @@
 Rails.application.config.after_initialize do |app|
   app.event_service.subscribe('ResponseCreated', PrepareResponseHandler, async: true, in_process: false)
   app.event_service.subscribe('ResponsePreparedForAtosExport', ResponseExportHandler, async: true, in_process: false)
+  app.event_service.subscribe('ResponsePrepared', ResponseEmailHandler, async: true, in_process: false)
   app.event_service.subscribe('ClaimCreated', PrepareClaimHandler, async: true, in_process: false)
   app.event_service.subscribe('ClaimPreparedForAtosExport', ClaimExportHandler, async: false, in_process: true)
   app.event_service.subscribe('BlobBuilt', BlobBuiltHandler, async: false, in_process: true)

--- a/vendor/gems/et_s3_to_azure/lib/rails/commands/azure_import/azure_import_command.rb
+++ b/vendor/gems/et_s3_to_azure/lib/rails/commands/azure_import/azure_import_command.rb
@@ -22,7 +22,7 @@ module EtS3ToAzure
     def help
       help_text_from_blobporter = `#{blobporter_path} --help 2>&1`
       puts <<-EOS
-        rails azure:import_files_from_s3 OPTIONS
+        rails azure_import:import_files_from_s3 OPTIONS
 
           This command delegates the work to 'blobporter' with certain options set according to the configuration
           for this system.  However, any further options can be passed on to the blobporter executable.  These options are :-


### PR DESCRIPTION
This PR changes the way the response mailer is hooked into the system. 
Before, the email was sent inline as part of the 'Response Preparation' which meant it went to try and read the pdf file literally about 6 mSec after it had written it.  My guess is that the blob service hadn't actually stored it by the time we went to read it.
So, I have removed the mailer from here - which makes more sense as the 'Response Preparation' does not really include sending a mail - the sending of the mail should happen after response preparation.

I have ran this through full system and got no errors