### PR TITLE
RST-1831 Internal pdf file has incorrect filename

### DIFF
--- a/app/commands/build_claim_command.rb
+++ b/app/commands/build_claim_command.rb
@@ -21,26 +21,19 @@ class BuildClaimCommand < BaseCommand
 
   validates :pdf_template_reference, inclusion: { in: ['et1-v1-en', 'et1-v1-cy'] }
 
-  def initialize(*args, reference_service: ReferenceService, allocator_service: UploadedFileAllocatorService.new, **kw_args)
+  def initialize(*args, reference_service: ReferenceService, **kw_args)
     super(*args, **kw_args)
     self.reference_service = reference_service
-    self.allocator_service = allocator_service
   end
 
   def apply(root_object, meta: {})
     apply_root_attributes(attributes, to: root_object)
-    allocate_pdf_file(root_object)
-    meta.merge! reference: root_object.reference,
-                pdf_url: allocator_service.allocated_url
+    meta.merge! reference: root_object.reference
   end
 
   private
 
-  attr_accessor :reference_service, :allocator_service
-
-  def allocate_pdf_file(root_object)
-    allocator_service.allocate('et1_atos_export.pdf', into: root_object)
-  end
+  attr_accessor :reference_service
 
   def apply_root_attributes(input_data, to:)
     to.attributes = input_data

--- a/app/commands/create_claim_command.rb
+++ b/app/commands/create_claim_command.rb
@@ -1,6 +1,6 @@
 class CreateClaimCommand < SerialSequenceCommand
   def initialize(uuid:, data:, **args)
-    super(uuid: uuid, data: data + [{ command: 'AssignReferenceToClaim', uuid: SecureRandom.uuid, data: {} }], **args)
+    super(uuid: uuid, data: data + extra_commands, **args)
   end
 
   def apply(root_object, meta: {})
@@ -10,8 +10,18 @@ class CreateClaimCommand < SerialSequenceCommand
     # that command so we pretend its from the BuildClaim command instead
     meta['BuildClaim'] ||= {}
     meta['BuildClaim'].merge! meta.delete('AssignReferenceToClaim')
+    meta['BuildClaim'].merge! meta.delete('PreAllocatePdfFile')
 
     root_object.save!
     EventService.publish('ClaimCreated', root_object)
+  end
+
+  private
+
+  def extra_commands
+    [
+      { command: 'AssignReferenceToClaim', uuid: SecureRandom.uuid, data: {} },
+      { command: 'PreAllocatePdfFile', uuid: SecureRandom.uuid, data: {} }
+    ]
   end
 end

--- a/app/commands/pre_allocate_pdf_file_command.rb
+++ b/app/commands/pre_allocate_pdf_file_command.rb
@@ -1,0 +1,25 @@
+class PreAllocatePdfFileCommand < BaseCommand
+  def initialize(*args, allocator_service: UploadedFileAllocatorService.new, **kw_args)
+    super(*args, **kw_args)
+    self.allocator_service = allocator_service
+  end
+
+  def apply(root_object, meta: {})
+    allocate_pdf_file(root_object)
+    meta.merge! pdf_url: allocator_service.allocated_url
+  end
+
+  private
+
+  attr_accessor :allocator_service
+
+  def allocate_pdf_file(root_object)
+    primary_claimant = root_object.primary_claimant
+    fn = "et1_#{scrubber(primary_claimant.first_name)}_#{scrubber(primary_claimant.last_name)}.pdf"
+    allocator_service.allocate(fn, into: root_object)
+  end
+
+  def scrubber(text)
+    text.gsub(/\s/, '_').gsub(/\W/, '').downcase
+  end
+end

--- a/app/commands/pre_allocate_pdf_file_command.rb
+++ b/app/commands/pre_allocate_pdf_file_command.rb
@@ -15,8 +15,8 @@ class PreAllocatePdfFileCommand < BaseCommand
 
   def allocate_pdf_file(root_object)
     primary_claimant = root_object.primary_claimant
-    fn = "et1_#{scrubber(primary_claimant.first_name)}_#{scrubber(primary_claimant.last_name)}.pdf"
-    allocator_service.allocate(fn, into: root_object)
+    filename = "et1_#{scrubber(primary_claimant.first_name)}_#{scrubber(primary_claimant.last_name)}.pdf"
+    allocator_service.allocate(filename, into: root_object)
   end
 
   def scrubber(text)

--- a/app/services/build_claim_pdf_file_service.rb
+++ b/app/services/build_claim_pdf_file_service.rb
@@ -11,12 +11,17 @@ class BuildClaimPdfFileService # rubocop:disable Metrics/ClassLength
   end
 
   def call
-    filename = 'et1_atos_export.pdf'
+    claimant = source.primary_claimant
+    filename = "et1_#{scrubber claimant.first_name}_#{scrubber claimant.last_name}.pdf"
     source.uploaded_files.build filename: filename,
                                 file: blob_for_pdf_file(filename)
   end
 
   private
+
+  def scrubber(text)
+    text.gsub(/\s/, '_').gsub(/\W/, '').downcase
+  end
 
   def pdf_fields
     result = {}

--- a/spec/commands/build_claim_command_spec.rb
+++ b/spec/commands/build_claim_command_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe BuildClaimCommand do
-  subject(:command) { described_class.new(uuid: uuid, data: data, allocator_service: mock_allocator_service) }
+  subject(:command) { described_class.new(uuid: uuid, data: data) }
 
   let(:uuid) { SecureRandom.uuid }
   let(:data) { build(:json_claim_data, :full, reference: 'myreference').as_json }
   let(:root_object) { build(:claim) }
-  let(:mock_allocator_service) { instance_double(UploadedFileAllocatorService, allocate: nil, allocated_url: 'http://mocked.com/allocated') }
 
   include_context 'with disabled event handlers'
 
@@ -30,28 +29,6 @@ RSpec.describe BuildClaimCommand do
 
       # Assert
       expect(meta).to include reference: data[:reference]
-    end
-
-    it 'adds a pdf_url to the meta' do
-      # Arrange
-      meta = {}
-
-      # Act
-      command.apply(root_object, meta: meta)
-
-      # Assert
-      expect(meta).to include pdf_url: 'http://mocked.com/allocated'
-    end
-
-    it 'uses the correct filename when calling the allocator' do
-      # Arrange
-      meta = {}
-
-      # Act
-      command.apply(root_object, meta: meta)
-
-      # Assert
-      expect(mock_allocator_service).to have_received(:allocate).with("et1_atos_export.pdf", anything)
     end
   end
 

--- a/spec/commands/create_claim_command_spec.rb
+++ b/spec/commands/create_claim_command_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe CreateClaimCommand do
+  subject(:command) { described_class.new(**data.as_json.symbolize_keys) }
+
+  let(:uuid) { SecureRandom.uuid }
+
+  it 'applys the build claimant command before the build claim command'
+end

--- a/spec/commands/create_claim_command_spec.rb
+++ b/spec/commands/create_claim_command_spec.rb
@@ -1,9 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe CreateClaimCommand do
-  subject(:command) { described_class.new(**data.as_json.symbolize_keys) }
-
-  let(:uuid) { SecureRandom.uuid }
-
-  it 'applys the build claimant command before the build claim command'
-end

--- a/spec/commands/pre_allocate_pdf_file_command_spec.rb
+++ b/spec/commands/pre_allocate_pdf_file_command_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe PreAllocatePdfFileCommand do
+  subject(:command) { described_class.new(uuid: uuid, data: {}, allocator_service: mock_allocator_service) }
+
+  let(:uuid) { SecureRandom.uuid }
+  let(:root_object) { build(:claim) }
+  let(:mock_allocator_service) { instance_double(UploadedFileAllocatorService, allocate: nil, allocated_url: 'http://mocked.com/allocated') }
+
+  include_context 'with disabled event handlers'
+
+  describe '#apply' do
+    it 'adds a pdf_url to the meta' do
+      # Arrange
+      meta = {}
+
+      # Act
+      command.apply(root_object, meta: meta)
+
+      # Assert
+      expect(meta).to include pdf_url: 'http://mocked.com/allocated'
+    end
+
+    it 'uses the correct filename when calling the allocator' do
+      # Arrange
+      meta = {}
+
+      # Act
+      command.apply(root_object, meta: meta)
+
+      # Assert
+      claimant = root_object.primary_claimant
+      fn = "et1_#{claimant.first_name.downcase}_#{claimant.last_name.downcase}.pdf"
+      expect(mock_allocator_service).to have_received(:allocate).with(fn, anything)
+    end
+  end
+end

--- a/spec/factories/claim_factory.rb
+++ b/spec/factories/claim_factory.rb
@@ -99,7 +99,6 @@ FactoryBot.define do
       secondary_claimants { [] }
       primary_respondent { build(:respondent, :example_data) }
       primary_representative { build(:representative, :example_data) }
-      uploaded_files { [build(:uploaded_file, :example_data)] }
     end
 
     trait :example_data_multiple_claimants do

--- a/spec/requests/v2/import_claim_spec.rb
+++ b/spec/requests/v2/import_claim_spec.rb
@@ -251,9 +251,13 @@ RSpec.describe 'Import Claim Request', type: :request do
 
     # @TODO RST-1741 - Once we only generating pdf's internally for et1 - the examples in here can be merged with the normal output folder shared examples
     shared_examples 'a claim imported with internally generated pdf' do
+      # A private scrubber to set expectations for the filename - replaces white space with underscores and any non word chars are removed
+      scrubber = ->(text) { text.gsub(/\s/, '_').gsub(/\W/, '') }
+
       it 'creates a valid pdf file the data filled in correctly' do
         # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
-        file = created_claim.uploaded_files.where(filename: "et1_atos_export.pdf").first
+        fn = "#{input_claim_factory.reference}_ET1_#{scrubber.call input_primary_claimant_factory.first_name}_#{scrubber.call input_primary_claimant_factory.last_name}.pdf"
+        file = created_claim.uploaded_files.where(filename: fn).first
         # @TODO Needs sorting
         tempfile = Tempfile.new
 

--- a/spec/requests/v2/import_claim_spec.rb
+++ b/spec/requests/v2/import_claim_spec.rb
@@ -239,7 +239,6 @@ RSpec.describe 'Import Claim Request', type: :request do
       it 'stores the rtf file with the correct filename and is a copy of the original' do
         # Assert - look for the correct file in the database and check its contents
         file = created_claim.uploaded_files.where(filename: input_rtf_file).first
-        # @TODO This needs sorting
         Dir.mktmpdir do |dir|
           full_path = File.join(dir, input_rtf_file)
           file.download_blob_to(full_path)
@@ -252,13 +251,12 @@ RSpec.describe 'Import Claim Request', type: :request do
     # @TODO RST-1741 - Once we only generating pdf's internally for et1 - the examples in here can be merged with the normal output folder shared examples
     shared_examples 'a claim imported with internally generated pdf' do
       # A private scrubber to set expectations for the filename - replaces white space with underscores and any non word chars are removed
-      scrubber = ->(text) { text.gsub(/\s/, '_').gsub(/\W/, '') }
+      scrubber = ->(text) { text.gsub(/\s/, '_').gsub(/\W/, '').downcase }
 
       it 'creates a valid pdf file the data filled in correctly' do
         # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
-        fn = "#{input_claim_factory.reference}_ET1_#{scrubber.call input_primary_claimant_factory.first_name}_#{scrubber.call input_primary_claimant_factory.last_name}.pdf"
-        file = created_claim.uploaded_files.where(filename: fn).first
-        # @TODO Needs sorting
+        filename = "et1_#{scrubber.call input_primary_claimant_factory.first_name}_#{scrubber.call input_primary_claimant_factory.last_name}.pdf"
+        file = created_claim.uploaded_files.where(filename: filename).first
         tempfile = Tempfile.new
 
         file.download_blob_to(tempfile.path)
@@ -280,7 +278,6 @@ RSpec.describe 'Import Claim Request', type: :request do
       it 'stores the pdf file with the correct filename and is a copy of the original' do
         # Assert - look for the correct file in the database and check its contents
         file = created_claim.uploaded_files.where(filename: input_pdf_file).first
-        # @TODO This needs sorting
         Dir.mktmpdir do |dir|
           full_path = File.join(dir, input_pdf_file)
           file.download_blob_to(full_path)


### PR DESCRIPTION
This PR solves a problem where the internal filename used for the customer's pdf's was simply et1_atos_export.pdf - so admin users would have had problems if downloading them as they wouldnt know from the filenames what they were.

The reason for this is that the 'pre allocation' of the pdf url was done at an early stage in the command chain, before the primary claimant was known.
This change adds an extra command on to the end of the chain to pre allocate the url - then fixes the actual file name generation in the pdf service