### PR TITLE
Added office data to meta of CreateClaim command RST-1657 API BuildCl…

### DIFF
--- a/app/commands/assign_office_to_claim_command.rb
+++ b/app/commands/assign_office_to_claim_command.rb
@@ -1,0 +1,35 @@
+class AssignOfficeToClaimCommand < BaseCommand
+  def initialize(*)
+    super
+    self.office_service = OfficeService
+  end
+
+  def apply(root_object, meta: {})
+    office = office_for(root_object)
+    assign_office_code_for(root_object, office)
+    assign_office_meta_for(meta, office)
+  end
+
+  private
+
+  attr_accessor :office_service
+
+  def assign_office_code_for(claim, office)
+    claim.office_code = office.code
+  end
+
+  def assign_office_meta_for(meta, office)
+    meta[:office] = {
+      name: office.name,
+      code: office.code,
+      telephone: office.telephone,
+      address: office.address
+    }
+  end
+
+  def office_for(claim)
+    resp = claim.primary_respondent
+    postcode_for_reference = resp.work_address.try(:post_code) || resp.address.try(:post_code)
+    office_service.lookup_postcode(postcode_for_reference)
+  end
+end

--- a/app/commands/assign_office_to_claim_command.rb
+++ b/app/commands/assign_office_to_claim_command.rb
@@ -23,7 +23,8 @@ class AssignOfficeToClaimCommand < BaseCommand
       name: office.name,
       code: office.code,
       telephone: office.telephone,
-      address: office.address
+      address: office.address,
+      email: office.email
     }
   end
 

--- a/app/commands/assign_office_to_claim_command.rb
+++ b/app/commands/assign_office_to_claim_command.rb
@@ -1,7 +1,7 @@
 class AssignOfficeToClaimCommand < BaseCommand
-  def initialize(*)
-    super
-    self.office_service = OfficeService
+  def initialize(*args, office_service: OfficeService, **kw_args)
+    super(*args, **kw_args)
+    self.office_service = office_service
   end
 
   def apply(root_object, meta: {})

--- a/app/commands/assign_reference_to_claim_command.rb
+++ b/app/commands/assign_reference_to_claim_command.rb
@@ -2,12 +2,10 @@ class AssignReferenceToClaimCommand < BaseCommand
   def initialize(*)
     super
     self.reference_service = ReferenceService
-    self.office_service = OfficeService
   end
 
   def apply(root_object, meta: {})
     if root_object.reference.blank?
-      assign_office_code_for(root_object)
       generate_reference_for(root_object)
     end
     meta.merge! reference: root_object.reference
@@ -15,17 +13,10 @@ class AssignReferenceToClaimCommand < BaseCommand
 
   private
 
-  attr_accessor :reference_service, :office_service
+  attr_accessor :reference_service
 
   def generate_reference_for(claim)
     reference = reference_service.next_number
     claim.reference = "#{claim.office_code}#{reference}00"
-  end
-
-  def assign_office_code_for(claim)
-    resp = claim.primary_respondent
-    postcode_for_reference = resp.work_address.try(:post_code) || resp.address.try(:post_code)
-    office = office_service.lookup_postcode(postcode_for_reference)
-    claim.office_code = office.code
   end
 end

--- a/app/commands/assign_reference_to_claim_command.rb
+++ b/app/commands/assign_reference_to_claim_command.rb
@@ -1,7 +1,7 @@
 class AssignReferenceToClaimCommand < BaseCommand
-  def initialize(*)
-    super
-    self.reference_service = ReferenceService
+  def initialize(*args, reference_service: ReferenceService, **kw_args)
+    super(*args, **kw_args)
+    self.reference_service = reference_service
   end
 
   def apply(root_object, meta: {})

--- a/app/commands/create_claim_command.rb
+++ b/app/commands/create_claim_command.rb
@@ -10,6 +10,7 @@ class CreateClaimCommand < SerialSequenceCommand
     # that command so we pretend its from the BuildClaim command instead
     meta['BuildClaim'] ||= {}
     meta['BuildClaim'].merge! meta.delete('AssignReferenceToClaim')
+    meta['BuildClaim'].merge! meta.delete('AssignOfficeToClaim')
     meta['BuildClaim'].merge! meta.delete('PreAllocatePdfFile')
 
     root_object.save!
@@ -20,6 +21,7 @@ class CreateClaimCommand < SerialSequenceCommand
 
   def extra_commands
     [
+      { command: 'AssignOfficeToClaim', uuid: SecureRandom.uuid, data: {} },
       { command: 'AssignReferenceToClaim', uuid: SecureRandom.uuid, data: {} },
       { command: 'PreAllocatePdfFile', uuid: SecureRandom.uuid, data: {} }
     ]

--- a/docs/api/acas_certificate/404_error_response_(certificate_not_found).md
+++ b/docs/api/acas_certificate/404_error_response_(certificate_not_found).md
@@ -39,8 +39,8 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: 7ee185a1-3c2f-479c-a338-ca17a4f85af7
-X-Runtime: 0.023548
+X-Request-Id: 2ad66bb0-5461-4695-aedf-03c17f00503a
+X-Runtime: 0.018898
 Content-Length: 22</pre>
 
 #### Status

--- a/docs/api/acas_certificate/422_error_response_(certificate_format_not_valid).md
+++ b/docs/api/acas_certificate/422_error_response_(certificate_format_not_valid).md
@@ -39,8 +39,8 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: 04a39f39-bbee-425c-9896-0a31b7491395
-X-Runtime: 0.024544
+X-Request-Id: ee887d2f-4144-4a5a-9b94-8034f1f2208d
+X-Runtime: 0.019383
 Content-Length: 86</pre>
 
 #### Status

--- a/docs/api/acas_certificate/500_error_response_(something_wrong_with_the_acas_server).md
+++ b/docs/api/acas_certificate/500_error_response_(something_wrong_with_the_acas_server).md
@@ -39,8 +39,8 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: 05298e0d-095a-49e4-b825-13576a3b6e87
-X-Runtime: 0.029221
+X-Request-Id: 8fa53fc1-c835-495d-9484-23e93a47e816
+X-Runtime: 0.016098
 Content-Length: 89</pre>
 
 #### Status

--- a/docs/api/acas_certificate/valid_certificate_response.md
+++ b/docs/api/acas_certificate/valid_certificate_response.md
@@ -40,8 +40,8 @@ Cookie: </pre>
 <pre>Content-Type: application/json; charset=utf-8
 ETag: W/&quot;f7ef2c04560c5ebd089a879b36bb84c6&quot;
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: e1773741-778a-4dcd-a932-3a59ba832260
-X-Runtime: 0.467326
+X-Request-Id: 68327b9f-393e-4ade-8b9a-3f7fe2e52513
+X-Runtime: 0.410589
 Content-Length: 43217</pre>
 
 #### Status

--- a/docs/api/blob_resource_(amazon_mode)/create_a_signed_s3_object_suitable_for_use_in_a_html_form_for_use_with_direct_upload.md
+++ b/docs/api/blob_resource_(amazon_mode)/create_a_signed_s3_object_suitable_for_use_in_a_html_form_for_use_with_direct_upload.md
@@ -30,7 +30,7 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "a7708bb7-9712-474f-bfba-1454bb1821e4",
+  "uuid": "97954f49-afe1-4e9b-be47-3b083fb68532",
   "command": "BuildBlob",
   "data": null,
   "async": false
@@ -39,7 +39,7 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/build_blob&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;a7708bb7-9712-474f-bfba-1454bb1821e4&quot;,
+  &quot;uuid&quot;: &quot;97954f49-afe1-4e9b-be47-3b083fb68532&quot;,
   &quot;command&quot;: &quot;BuildBlob&quot;,
   &quot;data&quot;: null,
   &quot;async&quot;: false
@@ -55,8 +55,8 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: b99bf5c4-13b1-48c4-b19c-4a414d7235db
-X-Runtime: 0.055107
+X-Request-Id: 33b813ae-692b-49bf-8669-abdaed2e299b
+X-Runtime: 0.077783
 Content-Length: 929</pre>
 
 #### Status
@@ -65,4 +65,4 @@ Content-Length: 929</pre>
 
 #### Body
 
-<pre>{"status":"accepted","meta":{"cloud_provider":"amazon"},"uuid":"a7708bb7-9712-474f-bfba-1454bb1821e4","data":{"fields":{"key":"direct_uploads/5902753a-6fad-4e59-9fb4-e677b7d140f6","success_action_status":"201","policy":"eyJleHBpcmF0aW9uIjoiMjAxOS0wMy0yOFQxNDo1OTozN1oiLCJjb25kaXRpb25zIjpbeyJidWNrZXQiOiJldGFwaWRpcmVjdGJ1Y2tldHRlc3QifSx7ImtleSI6ImRpcmVjdF91cGxvYWRzLzU5MDI3NTNhLTZmYWQtNGU1OS05ZmI0LWU2NzdiN2QxNDBmNiJ9LHsic3VjY2Vzc19hY3Rpb25fc3RhdHVzIjoiMjAxIn0seyJ4LWFtei1jcmVkZW50aWFsIjoiYWNjZXNzS2V5MS8yMDE5MDMyOC91cy1lYXN0LTEvczMvYXdzNF9yZXF1ZXN0In0seyJ4LWFtei1hbGdvcml0aG0iOiJBV1M0LUhNQUMtU0hBMjU2In0seyJ4LWFtei1kYXRlIjoiMjAxOTAzMjhUMTM1OTM3WiJ9XX0=","x-amz-credential":"accessKey1/20190328/us-east-1/s3/aws4_request","x-amz-algorithm":"AWS4-HMAC-SHA256","x-amz-date":"20190328T135937Z","x-amz-signature":"405a98e42c48ddd7b204ef3e13d2e00e53071f5d3fdc96c5254872a7225d3992"},"url":"http://localhost:9000/etapidirectbuckettest"}}</pre>
+<pre>{"status":"accepted","meta":{"cloud_provider":"amazon"},"uuid":"97954f49-afe1-4e9b-be47-3b083fb68532","data":{"fields":{"key":"direct_uploads/9e02d454-1945-414b-b38d-9142692ea8af","success_action_status":"201","policy":"eyJleHBpcmF0aW9uIjoiMjAxOS0wNC0yOVQwODozODo0MFoiLCJjb25kaXRpb25zIjpbeyJidWNrZXQiOiJldGFwaWRpcmVjdGJ1Y2tldHRlc3QifSx7ImtleSI6ImRpcmVjdF91cGxvYWRzLzllMDJkNDU0LTE5NDUtNDE0Yi1iMzhkLTkxNDI2OTJlYThhZiJ9LHsic3VjY2Vzc19hY3Rpb25fc3RhdHVzIjoiMjAxIn0seyJ4LWFtei1jcmVkZW50aWFsIjoiYWNjZXNzS2V5MS8yMDE5MDQyOS91cy1lYXN0LTEvczMvYXdzNF9yZXF1ZXN0In0seyJ4LWFtei1hbGdvcml0aG0iOiJBV1M0LUhNQUMtU0hBMjU2In0seyJ4LWFtei1kYXRlIjoiMjAxOTA0MjlUMDczODQwWiJ9XX0=","x-amz-credential":"accessKey1/20190429/us-east-1/s3/aws4_request","x-amz-algorithm":"AWS4-HMAC-SHA256","x-amz-date":"20190429T073840Z","x-amz-signature":"67fddc7537f40837da7afef00189b1db1db177763a537c9cc5839f055d62a32e"},"url":"http://localhost:9000/etapidirectbuckettest"}}</pre>

--- a/docs/api/blob_resource_(azure_mode)/create_a_signed_azure_url.md
+++ b/docs/api/blob_resource_(azure_mode)/create_a_signed_azure_url.md
@@ -30,7 +30,7 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "91ac28e6-edaf-41f5-9558-7ee92eb7da44",
+  "uuid": "0ae81de7-7a64-4b51-bfa1-5ce6784bb952",
   "command": "BuildBlob",
   "data": null,
   "async": false
@@ -39,7 +39,7 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/build_blob&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;91ac28e6-edaf-41f5-9558-7ee92eb7da44&quot;,
+  &quot;uuid&quot;: &quot;0ae81de7-7a64-4b51-bfa1-5ce6784bb952&quot;,
   &quot;command&quot;: &quot;BuildBlob&quot;,
   &quot;data&quot;: null,
   &quot;async&quot;: false
@@ -55,9 +55,9 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: ac5dd625-8528-428f-82b3-72875acb7ee3
-X-Runtime: 0.017840
-Content-Length: 712</pre>
+X-Request-Id: 71e68c25-8e05-4492-923e-6ac483d5015c
+X-Runtime: 0.022352
+Content-Length: 714</pre>
 
 #### Status
 
@@ -65,4 +65,4 @@ Content-Length: 712</pre>
 
 #### Body
 
-<pre>{"status":"accepted","meta":{"cloud_provider":"azure"},"uuid":"91ac28e6-edaf-41f5-9558-7ee92eb7da44","data":{"fields":{"key":"direct_uploads/7d0c3626-4416-4e40-a485-7b732c0ac0e6","permissions":"rw","version":"2016-05-31","expiry":"2019-03-28T14:04:37Z","resource":"b","signature":"dEMG7PCCqKiJtA79Ge6a7+bN1hepRHgezgxjNQ9iRhE="},"url":"http://localhost:10000/devstoreaccount1/et-api-direct-container/direct_uploads/7d0c3626-4416-4e40-a485-7b732c0ac0e6?sp=rw\u0026sv=2016-05-31\u0026se=2019-03-28T14%3A04%3A37Z\u0026sr=b\u0026sig=dEMG7PCCqKiJtA79Ge6a7%2BbN1hepRHgezgxjNQ9iRhE%3D","unsigned_url":"http://localhost:10000/devstoreaccount1/et-api-direct-container/direct_uploads/7d0c3626-4416-4e40-a485-7b732c0ac0e6"}}</pre>
+<pre>{"status":"accepted","meta":{"cloud_provider":"azure"},"uuid":"0ae81de7-7a64-4b51-bfa1-5ce6784bb952","data":{"fields":{"key":"direct_uploads/7375a41c-8e1e-48f1-9e52-0d8b96345a6f","permissions":"rw","version":"2016-05-31","expiry":"2019-04-29T07:43:41Z","resource":"b","signature":"z/9DRuz7kejjJ4c2gzZvzos+4hooywztUcGXBZqgD3w="},"url":"http://localhost:10000/devstoreaccount1/et-api-direct-container/direct_uploads/7375a41c-8e1e-48f1-9e52-0d8b96345a6f?sp=rw\u0026sv=2016-05-31\u0026se=2019-04-29T07%3A43%3A41Z\u0026sr=b\u0026sig=z%2F9DRuz7kejjJ4c2gzZvzos%2B4hooywztUcGXBZqgD3w%3D","unsigned_url":"http://localhost:10000/devstoreaccount1/et-api-direct-container/direct_uploads/7375a41c-8e1e-48f1-9e52-0d8b96345a6f"}}</pre>

--- a/docs/api/claim/create_a_claim_with_a_claimant,_respondent,_representative_and_claim_information_file.md
+++ b/docs/api/claim/create_a_claim_with_a_claimant,_respondent,_representative_and_claim_information_file.md
@@ -30,11 +30,11 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "fb699055-7b2e-4a0a-a349-632fabc1a398",
+  "uuid": "a38d57bc-2b77-4143-bd7b-95c9bc15b9f1",
   "command": "SerialSequence",
   "data": [
     {
-      "uuid": "f10768d3-65b6-4a70-897c-4be5b52700e0",
+      "uuid": "65787d84-eb34-43e0-bfe1-f22ba656acf7",
       "command": "BuildClaim",
       "data": {
         "employment_details": {
@@ -62,7 +62,7 @@ Cookie: </pre>
         "case_type": "Single",
         "jurisdiction": "2",
         "office_code": "22",
-        "date_of_receipt": "2019-03-28T13:59:38+0000",
+        "date_of_receipt": "2019-04-29T07:38:42+0000",
         "other_known_claimant_names": "",
         "discrimination_claims": [
 
@@ -83,7 +83,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "caed93fe-d7a7-4d6d-b0d0-3d3707977aab",
+      "uuid": "16d1b89f-daa1-4d5a-be58-16eebecb97ab",
       "command": "BuildPrimaryRespondent",
       "data": {
         "name": "dodgy_co",
@@ -119,7 +119,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "aa5a66b7-a135-49b2-b160-0ff50547fbf8",
+      "uuid": "126224bc-c791-4579-be17-49287e80e021",
       "command": "BuildPrimaryClaimant",
       "data": {
         "title": "Mr",
@@ -143,7 +143,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "eed5b483-6bf0-4829-9c55-4daf74693f30",
+      "uuid": "1a34b0d7-37de-4458-9724-705e3b5c0aac",
       "command": "BuildSecondaryClaimants",
       "data": [
         {
@@ -169,7 +169,7 @@ Cookie: </pre>
       ]
     },
     {
-      "uuid": "1419f799-fe6f-45d9-962d-c50cf3e6564f",
+      "uuid": "667df095-844d-4fb5-8c8f-0183a5e05328",
       "command": "BuildSecondaryRespondents",
       "data": [
         {
@@ -207,7 +207,7 @@ Cookie: </pre>
       ]
     },
     {
-      "uuid": "b8422977-fd5c-4bf8-bff5-123544764cf6",
+      "uuid": "d92e08ec-65e9-41b5-b8ff-58f5a0526546",
       "command": "BuildPrimaryRepresentative",
       "data": {
         "address_attributes": {
@@ -230,21 +230,21 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "9f4a03e3-410d-44e0-8c70-dfcbfdf572ee",
+      "uuid": "f459ef36-d5db-4c5f-bae2-061e49aec354",
       "command": "BuildPdfFile",
       "data": {
-        "data_url": "http://localhost:9000/etapibuckettest/CqULSCYEW8qBTaqu8Kfpfpgn?response-content-disposition=inline%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&response-content-type=application%2Fpdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190328T135938Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=b403f794796710a823a1c07f6a7379425552f1dcc402e79174158ec3a0f5b05c",
+        "data_url": "http://localhost:9000/etapibuckettest/fCq2U2Jrej3Gq9QLe6mLVhtT?response-content-disposition=inline%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&response-content-type=application%2Fpdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190429T073842Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=b4d7007d1cb700b9ca0253c061090dd6660722b0d50f9ba2eaf917b94cb4e527",
         "data_from_key": null,
         "filename": "et1_first_last.pdf",
         "checksum": "ee2714b8b731a8c1e95dffaa33f89728"
       }
     },
     {
-      "uuid": "d61842a3-709a-40ff-b844-07201c2963c4",
+      "uuid": "b74e0bfc-e5bd-44e2-a2e9-b27a0042ea72",
       "command": "BuildClaimDetailsFile",
       "data": {
         "data_url": null,
-        "data_from_key": "BxoVMnV8qRsenCoL8Rio5Dsy",
+        "data_from_key": "VFxMFyF8TiCEVrAWyKnJLG5M",
         "filename": "simple_user_with_rtf.rtf",
         "checksum": "e69a0344620b5040b7d0d1595b9c7726"
       }
@@ -255,11 +255,11 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/claims/build_claim&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;fb699055-7b2e-4a0a-a349-632fabc1a398&quot;,
+  &quot;uuid&quot;: &quot;a38d57bc-2b77-4143-bd7b-95c9bc15b9f1&quot;,
   &quot;command&quot;: &quot;SerialSequence&quot;,
   &quot;data&quot;: [
     {
-      &quot;uuid&quot;: &quot;f10768d3-65b6-4a70-897c-4be5b52700e0&quot;,
+      &quot;uuid&quot;: &quot;65787d84-eb34-43e0-bfe1-f22ba656acf7&quot;,
       &quot;command&quot;: &quot;BuildClaim&quot;,
       &quot;data&quot;: {
         &quot;employment_details&quot;: {
@@ -287,7 +287,7 @@ Cookie: </pre>
         &quot;case_type&quot;: &quot;Single&quot;,
         &quot;jurisdiction&quot;: &quot;2&quot;,
         &quot;office_code&quot;: &quot;22&quot;,
-        &quot;date_of_receipt&quot;: &quot;2019-03-28T13:59:38+0000&quot;,
+        &quot;date_of_receipt&quot;: &quot;2019-04-29T07:38:42+0000&quot;,
         &quot;other_known_claimant_names&quot;: &quot;&quot;,
         &quot;discrimination_claims&quot;: [
 
@@ -308,7 +308,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;caed93fe-d7a7-4d6d-b0d0-3d3707977aab&quot;,
+      &quot;uuid&quot;: &quot;16d1b89f-daa1-4d5a-be58-16eebecb97ab&quot;,
       &quot;command&quot;: &quot;BuildPrimaryRespondent&quot;,
       &quot;data&quot;: {
         &quot;name&quot;: &quot;dodgy_co&quot;,
@@ -344,7 +344,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;aa5a66b7-a135-49b2-b160-0ff50547fbf8&quot;,
+      &quot;uuid&quot;: &quot;126224bc-c791-4579-be17-49287e80e021&quot;,
       &quot;command&quot;: &quot;BuildPrimaryClaimant&quot;,
       &quot;data&quot;: {
         &quot;title&quot;: &quot;Mr&quot;,
@@ -368,7 +368,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;eed5b483-6bf0-4829-9c55-4daf74693f30&quot;,
+      &quot;uuid&quot;: &quot;1a34b0d7-37de-4458-9724-705e3b5c0aac&quot;,
       &quot;command&quot;: &quot;BuildSecondaryClaimants&quot;,
       &quot;data&quot;: [
         {
@@ -394,7 +394,7 @@ Cookie: </pre>
       ]
     },
     {
-      &quot;uuid&quot;: &quot;1419f799-fe6f-45d9-962d-c50cf3e6564f&quot;,
+      &quot;uuid&quot;: &quot;667df095-844d-4fb5-8c8f-0183a5e05328&quot;,
       &quot;command&quot;: &quot;BuildSecondaryRespondents&quot;,
       &quot;data&quot;: [
         {
@@ -432,7 +432,7 @@ Cookie: </pre>
       ]
     },
     {
-      &quot;uuid&quot;: &quot;b8422977-fd5c-4bf8-bff5-123544764cf6&quot;,
+      &quot;uuid&quot;: &quot;d92e08ec-65e9-41b5-b8ff-58f5a0526546&quot;,
       &quot;command&quot;: &quot;BuildPrimaryRepresentative&quot;,
       &quot;data&quot;: {
         &quot;address_attributes&quot;: {
@@ -455,21 +455,21 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;9f4a03e3-410d-44e0-8c70-dfcbfdf572ee&quot;,
+      &quot;uuid&quot;: &quot;f459ef36-d5db-4c5f-bae2-061e49aec354&quot;,
       &quot;command&quot;: &quot;BuildPdfFile&quot;,
       &quot;data&quot;: {
-        &quot;data_url&quot;: &quot;http://localhost:9000/etapibuckettest/CqULSCYEW8qBTaqu8Kfpfpgn?response-content-disposition=inline%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&amp;response-content-type=application%2Fpdf&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20190328T135938Z&amp;X-Amz-Expires=300&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=b403f794796710a823a1c07f6a7379425552f1dcc402e79174158ec3a0f5b05c&quot;,
+        &quot;data_url&quot;: &quot;http://localhost:9000/etapibuckettest/fCq2U2Jrej3Gq9QLe6mLVhtT?response-content-disposition=inline%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&amp;response-content-type=application%2Fpdf&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20190429T073842Z&amp;X-Amz-Expires=300&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=b4d7007d1cb700b9ca0253c061090dd6660722b0d50f9ba2eaf917b94cb4e527&quot;,
         &quot;data_from_key&quot;: null,
         &quot;filename&quot;: &quot;et1_first_last.pdf&quot;,
         &quot;checksum&quot;: &quot;ee2714b8b731a8c1e95dffaa33f89728&quot;
       }
     },
     {
-      &quot;uuid&quot;: &quot;d61842a3-709a-40ff-b844-07201c2963c4&quot;,
+      &quot;uuid&quot;: &quot;b74e0bfc-e5bd-44e2-a2e9-b27a0042ea72&quot;,
       &quot;command&quot;: &quot;BuildClaimDetailsFile&quot;,
       &quot;data&quot;: {
         &quot;data_url&quot;: null,
-        &quot;data_from_key&quot;: &quot;BxoVMnV8qRsenCoL8Rio5Dsy&quot;,
+        &quot;data_from_key&quot;: &quot;VFxMFyF8TiCEVrAWyKnJLG5M&quot;,
         &quot;filename&quot;: &quot;simple_user_with_rtf.rtf&quot;,
         &quot;checksum&quot;: &quot;e69a0344620b5040b7d0d1595b9c7726&quot;
       }
@@ -487,9 +487,9 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: 62924806-9fe7-4015-9383-d8b334d54ed2
-X-Runtime: 0.056700
-Content-Length: 803</pre>
+X-Request-Id: 1b79afbf-5592-4d85-a22c-8158782de0c0
+X-Runtime: 0.044623
+Content-Length: 976</pre>
 
 #### Status
 
@@ -497,4 +497,4 @@ Content-Length: 803</pre>
 
 #### Body
 
-<pre>{"status":"accepted","meta":{"BuildClaim":{"reference":"222000000300","pdf_url":"http://localhost:9000/etapibuckettest/kfTGnbnCYyekvbb6QvSTWh6E?response-content-disposition=attachment%3B%20filename%3D%22et1_atos_export.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_atos_export.pdf\u0026X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20190328T135939Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=edcb6a7d622ed63b17cde3b86894179c497ff7022a3ebc464bb6660df7c78df4"},"BuildPrimaryRespondent":{},"BuildPrimaryClaimant":{},"BuildSecondaryClaimants":{},"BuildSecondaryRespondents":{},"BuildPrimaryRepresentative":{},"BuildPdfFile":{},"BuildClaimDetailsFile":{}},"uuid":"fb699055-7b2e-4a0a-a349-632fabc1a398"}</pre>
+<pre>{"status":"accepted","meta":{"BuildClaim":{"reference":"222000000300","office":{"name":"London Central","code":22,"telephone":"020 7273 8603","address":"Victory House, 30-34 Kingsway, London WC2B 6EX","email":"londoncentralet@hmcts.gsi.gov.uk"},"pdf_url":"http://localhost:9000/etapibuckettest/a56E7Z44CPx2KPzJFAWVQEB4?response-content-disposition=attachment%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf\u0026X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20190429T073842Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=a7100bfc8dab0acfdaa1273dc31a871a55cbe0f58f1ad640e7bf19d5cf01b50b"},"BuildPrimaryRespondent":{},"BuildPrimaryClaimant":{},"BuildSecondaryClaimants":{},"BuildSecondaryRespondents":{},"BuildPrimaryRepresentative":{},"BuildPdfFile":{},"BuildClaimDetailsFile":{}},"uuid":"a38d57bc-2b77-4143-bd7b-95c9bc15b9f1"}</pre>

--- a/docs/api/claim/create_a_claim_with_a_claimant,_respondent_and_representative_with_external_pdf.md
+++ b/docs/api/claim/create_a_claim_with_a_claimant,_respondent_and_representative_with_external_pdf.md
@@ -30,11 +30,11 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "1d51af80-de22-42b7-891b-0ad40e045d9f",
+  "uuid": "98daa30f-046b-4325-b679-1815944bb368",
   "command": "SerialSequence",
   "data": [
     {
-      "uuid": "bbaf9cf8-a20a-4246-bff5-502e62b377a3",
+      "uuid": "c5f756a5-59c3-4c9b-b457-e10b3bf41e64",
       "command": "BuildClaim",
       "data": {
         "employment_details": {
@@ -62,7 +62,7 @@ Cookie: </pre>
         "case_type": "Single",
         "jurisdiction": "2",
         "office_code": "22",
-        "date_of_receipt": "2019-03-28T13:59:37+0000",
+        "date_of_receipt": "2019-04-29T07:38:41+0000",
         "other_known_claimant_names": "",
         "discrimination_claims": [
 
@@ -83,7 +83,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "9981fee8-3894-4904-bc8e-dfe5add28740",
+      "uuid": "b471f19e-cf1d-43e9-ba50-36d60081fd6b",
       "command": "BuildPrimaryRespondent",
       "data": {
         "name": "dodgy_co",
@@ -119,7 +119,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "d9b5094a-db95-4d80-8eb4-f5c130918f07",
+      "uuid": "4f57a754-8dba-4dc5-8e9a-2235aa5a2aa3",
       "command": "BuildPrimaryClaimant",
       "data": {
         "title": "Mr",
@@ -143,7 +143,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "cdd235d9-d0dd-4ae2-8d7c-455b83f1d741",
+      "uuid": "e2bdf387-1860-46a7-9701-c5268c80db81",
       "command": "BuildSecondaryClaimants",
       "data": [
         {
@@ -169,7 +169,7 @@ Cookie: </pre>
       ]
     },
     {
-      "uuid": "fafe4b66-51dc-4ab3-bb9b-6e33c202a043",
+      "uuid": "3cbcd3b2-23ec-437e-ad9d-98d88a39f9ee",
       "command": "BuildSecondaryRespondents",
       "data": [
         {
@@ -207,7 +207,7 @@ Cookie: </pre>
       ]
     },
     {
-      "uuid": "b1227e5b-3a7e-4b31-a261-1fee4c6e795b",
+      "uuid": "1addfce0-473c-44e8-813b-3b6599973f06",
       "command": "BuildPrimaryRepresentative",
       "data": {
         "address_attributes": {
@@ -230,10 +230,10 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "4e9f7aaa-69e0-44f4-ac26-9cf3a2fee15d",
+      "uuid": "6ec28766-6f34-4e82-8d37-9bbe5717fcbe",
       "command": "BuildPdfFile",
       "data": {
-        "data_url": "http://localhost:9000/etapibuckettest/cEQjHxpSW34AzGPgC7vDwJMg?response-content-disposition=inline%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&response-content-type=application%2Fpdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190328T135938Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=92d038209c35ea2f16272f53e277c8041439b272c14d5070324ec417e969057e",
+        "data_url": "http://localhost:9000/etapibuckettest/JZG5ZjkXTmvF4UKjvu1hZkLm?response-content-disposition=inline%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&response-content-type=application%2Fpdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190429T073841Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=998eb4e2241eb427b6dc17ee2190318290b7bbf77366a2450de9bd29d0033b94",
         "data_from_key": null,
         "filename": "et1_first_last.pdf",
         "checksum": "ee2714b8b731a8c1e95dffaa33f89728"
@@ -245,11 +245,11 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/claims/build_claim&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;1d51af80-de22-42b7-891b-0ad40e045d9f&quot;,
+  &quot;uuid&quot;: &quot;98daa30f-046b-4325-b679-1815944bb368&quot;,
   &quot;command&quot;: &quot;SerialSequence&quot;,
   &quot;data&quot;: [
     {
-      &quot;uuid&quot;: &quot;bbaf9cf8-a20a-4246-bff5-502e62b377a3&quot;,
+      &quot;uuid&quot;: &quot;c5f756a5-59c3-4c9b-b457-e10b3bf41e64&quot;,
       &quot;command&quot;: &quot;BuildClaim&quot;,
       &quot;data&quot;: {
         &quot;employment_details&quot;: {
@@ -277,7 +277,7 @@ Cookie: </pre>
         &quot;case_type&quot;: &quot;Single&quot;,
         &quot;jurisdiction&quot;: &quot;2&quot;,
         &quot;office_code&quot;: &quot;22&quot;,
-        &quot;date_of_receipt&quot;: &quot;2019-03-28T13:59:37+0000&quot;,
+        &quot;date_of_receipt&quot;: &quot;2019-04-29T07:38:41+0000&quot;,
         &quot;other_known_claimant_names&quot;: &quot;&quot;,
         &quot;discrimination_claims&quot;: [
 
@@ -298,7 +298,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;9981fee8-3894-4904-bc8e-dfe5add28740&quot;,
+      &quot;uuid&quot;: &quot;b471f19e-cf1d-43e9-ba50-36d60081fd6b&quot;,
       &quot;command&quot;: &quot;BuildPrimaryRespondent&quot;,
       &quot;data&quot;: {
         &quot;name&quot;: &quot;dodgy_co&quot;,
@@ -334,7 +334,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;d9b5094a-db95-4d80-8eb4-f5c130918f07&quot;,
+      &quot;uuid&quot;: &quot;4f57a754-8dba-4dc5-8e9a-2235aa5a2aa3&quot;,
       &quot;command&quot;: &quot;BuildPrimaryClaimant&quot;,
       &quot;data&quot;: {
         &quot;title&quot;: &quot;Mr&quot;,
@@ -358,7 +358,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;cdd235d9-d0dd-4ae2-8d7c-455b83f1d741&quot;,
+      &quot;uuid&quot;: &quot;e2bdf387-1860-46a7-9701-c5268c80db81&quot;,
       &quot;command&quot;: &quot;BuildSecondaryClaimants&quot;,
       &quot;data&quot;: [
         {
@@ -384,7 +384,7 @@ Cookie: </pre>
       ]
     },
     {
-      &quot;uuid&quot;: &quot;fafe4b66-51dc-4ab3-bb9b-6e33c202a043&quot;,
+      &quot;uuid&quot;: &quot;3cbcd3b2-23ec-437e-ad9d-98d88a39f9ee&quot;,
       &quot;command&quot;: &quot;BuildSecondaryRespondents&quot;,
       &quot;data&quot;: [
         {
@@ -422,7 +422,7 @@ Cookie: </pre>
       ]
     },
     {
-      &quot;uuid&quot;: &quot;b1227e5b-3a7e-4b31-a261-1fee4c6e795b&quot;,
+      &quot;uuid&quot;: &quot;1addfce0-473c-44e8-813b-3b6599973f06&quot;,
       &quot;command&quot;: &quot;BuildPrimaryRepresentative&quot;,
       &quot;data&quot;: {
         &quot;address_attributes&quot;: {
@@ -445,10 +445,10 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;4e9f7aaa-69e0-44f4-ac26-9cf3a2fee15d&quot;,
+      &quot;uuid&quot;: &quot;6ec28766-6f34-4e82-8d37-9bbe5717fcbe&quot;,
       &quot;command&quot;: &quot;BuildPdfFile&quot;,
       &quot;data&quot;: {
-        &quot;data_url&quot;: &quot;http://localhost:9000/etapibuckettest/cEQjHxpSW34AzGPgC7vDwJMg?response-content-disposition=inline%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&amp;response-content-type=application%2Fpdf&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20190328T135938Z&amp;X-Amz-Expires=300&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=92d038209c35ea2f16272f53e277c8041439b272c14d5070324ec417e969057e&quot;,
+        &quot;data_url&quot;: &quot;http://localhost:9000/etapibuckettest/JZG5ZjkXTmvF4UKjvu1hZkLm?response-content-disposition=inline%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&amp;response-content-type=application%2Fpdf&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20190429T073841Z&amp;X-Amz-Expires=300&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=998eb4e2241eb427b6dc17ee2190318290b7bbf77366a2450de9bd29d0033b94&quot;,
         &quot;data_from_key&quot;: null,
         &quot;filename&quot;: &quot;et1_first_last.pdf&quot;,
         &quot;checksum&quot;: &quot;ee2714b8b731a8c1e95dffaa33f89728&quot;
@@ -467,9 +467,9 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: 32c83292-20c5-4c6f-8f5a-6b2c9b0e13e0
-X-Runtime: 0.316393
-Content-Length: 776</pre>
+X-Request-Id: 57a52b91-218f-4c20-bf16-d4e00041e1d5
+X-Runtime: 0.197300
+Content-Length: 949</pre>
 
 #### Status
 
@@ -477,4 +477,4 @@ Content-Length: 776</pre>
 
 #### Body
 
-<pre>{"status":"accepted","meta":{"BuildClaim":{"reference":"222000000100","pdf_url":"http://localhost:9000/etapibuckettest/NQsjMtbD7L8RTsvVpHxjcuu4?response-content-disposition=attachment%3B%20filename%3D%22et1_atos_export.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_atos_export.pdf\u0026X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20190328T135938Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=6bdb5767f06e8276ad1b175ca206f8e909ea3b6dbc9b4544d0618a45abc931f1"},"BuildPrimaryRespondent":{},"BuildPrimaryClaimant":{},"BuildSecondaryClaimants":{},"BuildSecondaryRespondents":{},"BuildPrimaryRepresentative":{},"BuildPdfFile":{}},"uuid":"1d51af80-de22-42b7-891b-0ad40e045d9f"}</pre>
+<pre>{"status":"accepted","meta":{"BuildClaim":{"reference":"222000000100","office":{"name":"London Central","code":22,"telephone":"020 7273 8603","address":"Victory House, 30-34 Kingsway, London WC2B 6EX","email":"londoncentralet@hmcts.gsi.gov.uk"},"pdf_url":"http://localhost:9000/etapibuckettest/Rqoev3d6hP7KXtGk3e1QLXgv?response-content-disposition=attachment%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf\u0026X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20190429T073841Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=3632d8761ca3ed45201fce7390c23abb9881997868f6a2861adf5dfb5a2e4250"},"BuildPrimaryRespondent":{},"BuildPrimaryClaimant":{},"BuildSecondaryClaimants":{},"BuildSecondaryRespondents":{},"BuildPrimaryRepresentative":{},"BuildPdfFile":{}},"uuid":"98daa30f-046b-4325-b679-1815944bb368"}</pre>

--- a/docs/api/claim/create_a_claim_with_a_claimant,_respondent_and_representative_without_external_pdf.md
+++ b/docs/api/claim/create_a_claim_with_a_claimant,_respondent_and_representative_without_external_pdf.md
@@ -30,11 +30,11 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "ef243870-4d35-4a35-85f1-5313fd1449ad",
+  "uuid": "106144b2-537b-4066-b4bc-2982531d9b9a",
   "command": "SerialSequence",
   "data": [
     {
-      "uuid": "3afb0891-ad1c-41f2-9426-190db224e5b2",
+      "uuid": "d250f3c3-2343-48f1-a6a5-bec2216922ee",
       "command": "BuildClaim",
       "data": {
         "employment_details": {
@@ -62,7 +62,7 @@ Cookie: </pre>
         "case_type": "Single",
         "jurisdiction": "2",
         "office_code": "22",
-        "date_of_receipt": "2019-03-28T13:59:38+0000",
+        "date_of_receipt": "2019-04-29T07:38:41+0000",
         "other_known_claimant_names": "",
         "discrimination_claims": [
 
@@ -83,7 +83,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "fa83fc09-7d22-4b37-88f6-0645d84ed3ab",
+      "uuid": "24451846-9eac-4a4c-9c89-89bb3c4cb11f",
       "command": "BuildPrimaryRespondent",
       "data": {
         "name": "dodgy_co",
@@ -119,7 +119,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "8d57eef0-9945-4c8b-999a-bee33f888af4",
+      "uuid": "1e414de6-84f9-4b6d-a98c-0cc70f295c54",
       "command": "BuildPrimaryClaimant",
       "data": {
         "title": "Mr",
@@ -143,7 +143,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "e51d7e88-dbb4-4058-bdeb-e7f47ae9c598",
+      "uuid": "32318832-f033-4639-929f-9be3f80ee6ec",
       "command": "BuildSecondaryClaimants",
       "data": [
         {
@@ -169,7 +169,7 @@ Cookie: </pre>
       ]
     },
     {
-      "uuid": "5b843227-3416-4907-abfb-3c7cef1107cf",
+      "uuid": "581709a7-fb34-4323-a541-0ba14e4be901",
       "command": "BuildSecondaryRespondents",
       "data": [
         {
@@ -207,7 +207,7 @@ Cookie: </pre>
       ]
     },
     {
-      "uuid": "b7ac17f4-8fcf-4f36-9c55-45162584e47c",
+      "uuid": "1bdf8ec9-a993-46e2-802a-c4a001070de3",
       "command": "BuildPrimaryRepresentative",
       "data": {
         "address_attributes": {
@@ -235,11 +235,11 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/claims/build_claim&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;ef243870-4d35-4a35-85f1-5313fd1449ad&quot;,
+  &quot;uuid&quot;: &quot;106144b2-537b-4066-b4bc-2982531d9b9a&quot;,
   &quot;command&quot;: &quot;SerialSequence&quot;,
   &quot;data&quot;: [
     {
-      &quot;uuid&quot;: &quot;3afb0891-ad1c-41f2-9426-190db224e5b2&quot;,
+      &quot;uuid&quot;: &quot;d250f3c3-2343-48f1-a6a5-bec2216922ee&quot;,
       &quot;command&quot;: &quot;BuildClaim&quot;,
       &quot;data&quot;: {
         &quot;employment_details&quot;: {
@@ -267,7 +267,7 @@ Cookie: </pre>
         &quot;case_type&quot;: &quot;Single&quot;,
         &quot;jurisdiction&quot;: &quot;2&quot;,
         &quot;office_code&quot;: &quot;22&quot;,
-        &quot;date_of_receipt&quot;: &quot;2019-03-28T13:59:38+0000&quot;,
+        &quot;date_of_receipt&quot;: &quot;2019-04-29T07:38:41+0000&quot;,
         &quot;other_known_claimant_names&quot;: &quot;&quot;,
         &quot;discrimination_claims&quot;: [
 
@@ -288,7 +288,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;fa83fc09-7d22-4b37-88f6-0645d84ed3ab&quot;,
+      &quot;uuid&quot;: &quot;24451846-9eac-4a4c-9c89-89bb3c4cb11f&quot;,
       &quot;command&quot;: &quot;BuildPrimaryRespondent&quot;,
       &quot;data&quot;: {
         &quot;name&quot;: &quot;dodgy_co&quot;,
@@ -324,7 +324,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;8d57eef0-9945-4c8b-999a-bee33f888af4&quot;,
+      &quot;uuid&quot;: &quot;1e414de6-84f9-4b6d-a98c-0cc70f295c54&quot;,
       &quot;command&quot;: &quot;BuildPrimaryClaimant&quot;,
       &quot;data&quot;: {
         &quot;title&quot;: &quot;Mr&quot;,
@@ -348,7 +348,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;e51d7e88-dbb4-4058-bdeb-e7f47ae9c598&quot;,
+      &quot;uuid&quot;: &quot;32318832-f033-4639-929f-9be3f80ee6ec&quot;,
       &quot;command&quot;: &quot;BuildSecondaryClaimants&quot;,
       &quot;data&quot;: [
         {
@@ -374,7 +374,7 @@ Cookie: </pre>
       ]
     },
     {
-      &quot;uuid&quot;: &quot;5b843227-3416-4907-abfb-3c7cef1107cf&quot;,
+      &quot;uuid&quot;: &quot;581709a7-fb34-4323-a541-0ba14e4be901&quot;,
       &quot;command&quot;: &quot;BuildSecondaryRespondents&quot;,
       &quot;data&quot;: [
         {
@@ -412,7 +412,7 @@ Cookie: </pre>
       ]
     },
     {
-      &quot;uuid&quot;: &quot;b7ac17f4-8fcf-4f36-9c55-45162584e47c&quot;,
+      &quot;uuid&quot;: &quot;1bdf8ec9-a993-46e2-802a-c4a001070de3&quot;,
       &quot;command&quot;: &quot;BuildPrimaryRepresentative&quot;,
       &quot;data&quot;: {
         &quot;address_attributes&quot;: {
@@ -447,9 +447,9 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: b20ec25f-4c53-4cae-85dc-dcb91a4ac3b9
-X-Runtime: 0.132349
-Content-Length: 758</pre>
+X-Request-Id: 416f28ac-8b43-45af-8e78-06d97ead34a6
+X-Runtime: 0.036581
+Content-Length: 931</pre>
 
 #### Status
 
@@ -457,4 +457,4 @@ Content-Length: 758</pre>
 
 #### Body
 
-<pre>{"status":"accepted","meta":{"BuildClaim":{"reference":"222000000200","pdf_url":"http://localhost:9000/etapibuckettest/TJXjHxXu1E4SQLZD37w4Yetn?response-content-disposition=attachment%3B%20filename%3D%22et1_atos_export.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_atos_export.pdf\u0026X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20190328T135938Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=52b1582ae1c2300966a44d08459a819e79d8e94ab4caf951aa2bc8ad80f05503"},"BuildPrimaryRespondent":{},"BuildPrimaryClaimant":{},"BuildSecondaryClaimants":{},"BuildSecondaryRespondents":{},"BuildPrimaryRepresentative":{}},"uuid":"ef243870-4d35-4a35-85f1-5313fd1449ad"}</pre>
+<pre>{"status":"accepted","meta":{"BuildClaim":{"reference":"222000000200","office":{"name":"London Central","code":22,"telephone":"020 7273 8603","address":"Victory House, 30-34 Kingsway, London WC2B 6EX","email":"londoncentralet@hmcts.gsi.gov.uk"},"pdf_url":"http://localhost:9000/etapibuckettest/5KL3ugfH8V8DEn7VaTsxZ2Eh?response-content-disposition=attachment%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf\u0026X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20190429T073842Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=4b81e1773553ef2908afa8e61a57a1a6af83a0f9af9a69eea606a6606ca1f15e"},"BuildPrimaryRespondent":{},"BuildPrimaryClaimant":{},"BuildSecondaryClaimants":{},"BuildSecondaryRespondents":{},"BuildPrimaryRepresentative":{}},"uuid":"106144b2-537b-4066-b4bc-2982531d9b9a"}</pre>

--- a/docs/api/claim_reference/create_a_reference_number_based_on_post_code.md
+++ b/docs/api/claim_reference/create_a_reference_number_based_on_post_code.md
@@ -30,7 +30,7 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "40da2c52-2f5f-4bea-ab3b-42183e7dc9ad",
+  "uuid": "dd0da189-1cf4-423a-9850-31455394fc4f",
   "command": "CreateReference",
   "async": false,
   "data": {
@@ -41,7 +41,7 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/references/create_reference&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;40da2c52-2f5f-4bea-ab3b-42183e7dc9ad&quot;,
+  &quot;uuid&quot;: &quot;dd0da189-1cf4-423a-9850-31455394fc4f&quot;,
   &quot;command&quot;: &quot;CreateReference&quot;,
   &quot;async&quot;: false,
   &quot;data&quot;: {
@@ -58,10 +58,10 @@ Cookie: </pre>
 #### Headers
 
 <pre>Content-Type: application/json; charset=utf-8
-ETag: W/&quot;edb64e48bc019955294286106997f8af&quot;
+ETag: W/&quot;389d8cc7c8914f21f74ce1fea5e99d2c&quot;
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 1bd05960-fb01-4624-b4e1-1afda416c7c4
-X-Runtime: 0.039252
+X-Request-Id: 95ccaf97-fa6a-44b2-9a78-13464e85a074
+X-Runtime: 0.028165
 Content-Length: 246</pre>
 
 #### Status
@@ -70,4 +70,4 @@ Content-Length: 246</pre>
 
 #### Body
 
-<pre>{"status":"created","meta":{},"uuid":"40da2c52-2f5f-4bea-ab3b-42183e7dc9ad","data":{"reference":"222000139200","office":{"code":"22","name":"London Central","address":"Victory House, 30-34 Kingsway, London WC2B 6EX","telephone":"020 7273 8603"}}}</pre>
+<pre>{"status":"created","meta":{},"uuid":"dd0da189-1cf4-423a-9850-31455394fc4f","data":{"reference":"222000036100","office":{"code":"22","name":"London Central","address":"Victory House, 30-34 Kingsway, London WC2B 6EX","telephone":"020 7273 8603"}}}</pre>

--- a/docs/api/diversity_response/create_a_diversity_response.md
+++ b/docs/api/diversity_response/create_a_diversity_response.md
@@ -30,7 +30,7 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "ec12440a-3439-4ec9-b1fa-2d85f89c242a",
+  "uuid": "a210b3e4-5622-49ce-89b3-ee06d276a12d",
   "command": "BuildDiversityResponse",
   "data": {
     "claim_type": "Discrimination",
@@ -52,7 +52,7 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/diversity/build_diversity_response&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;ec12440a-3439-4ec9-b1fa-2d85f89c242a&quot;,
+  &quot;uuid&quot;: &quot;a210b3e4-5622-49ce-89b3-ee06d276a12d&quot;,
   &quot;command&quot;: &quot;BuildDiversityResponse&quot;,
   &quot;data&quot;: {
     &quot;claim_type&quot;: &quot;Discrimination&quot;,
@@ -80,10 +80,10 @@ Cookie: </pre>
 #### Headers
 
 <pre>Content-Type: application/json; charset=utf-8
-ETag: W/&quot;5d084ac4b42d969f337defe6b9e00506&quot;
+ETag: W/&quot;37948e59c7d27593fd85b955bae21fde&quot;
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 6ad2f15a-5a6c-4821-981d-293c8ee4442e
-X-Runtime: 0.044661
+X-Request-Id: 3812ec2c-3f0a-4f9b-89df-300212c8fdc7
+X-Runtime: 0.033990
 Content-Length: 67</pre>
 
 #### Status
@@ -92,4 +92,4 @@ Content-Length: 67</pre>
 
 #### Body
 
-<pre>{"status":"accepted","uuid":"ec12440a-3439-4ec9-b1fa-2d85f89c242a"}</pre>
+<pre>{"status":"accepted","uuid":"a210b3e4-5622-49ce-89b3-ee06d276a12d"}</pre>

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -49,12 +49,6 @@ A response is the response from the employer who the claim is made against.  It 
 * [Response not created - this example shows invalid case number due to the office code not being correct](response/response_not_created_-_this_example_shows_invalid_case_number_due_to_the_office_code_not_being_correct.md)
 * [Response successfully created](response/response_successfully_created.md)
 
-## Signed S3 Resource
-
-Signed S3 resource
-
-* [Create a signed s3 object suitable for use in a HTML form for use with direct upload](signed_s3_resource/create_a_signed_s3_object_suitable_for_use_in_a_html_form_for_use_with_direct_upload.md)
-
 ## Validate Claimants File
 
 A service perform validation using various commands

--- a/docs/api/open_api.json
+++ b/docs/api/open_api.json
@@ -52,7 +52,7 @@
               "properties": {
                 "uuid": {
                   "type": "string",
-                  "example": "a7708bb7-9712-474f-bfba-1454bb1821e4",
+                  "example": "97954f49-afe1-4e9b-be47-3b083fb68532",
                   "description": "A unique ID produced by the client to refer to this command"
                 },
                 "data": {
@@ -94,12 +94,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "b99bf5c4-13b1-48c4-b19c-4a414d7235db"
+                "x-example-value": "33b813ae-692b-49bf-8669-abdaed2e299b"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.055107"
+                "x-example-value": "0.077783"
               },
               "Content-Length": {
                 "description": "",
@@ -113,16 +113,16 @@
                 "meta": {
                   "cloud_provider": "amazon"
                 },
-                "uuid": "a7708bb7-9712-474f-bfba-1454bb1821e4",
+                "uuid": "97954f49-afe1-4e9b-be47-3b083fb68532",
                 "data": {
                   "fields": {
-                    "key": "direct_uploads/5902753a-6fad-4e59-9fb4-e677b7d140f6",
+                    "key": "direct_uploads/9e02d454-1945-414b-b38d-9142692ea8af",
                     "success_action_status": "201",
-                    "policy": "eyJleHBpcmF0aW9uIjoiMjAxOS0wMy0yOFQxNDo1OTozN1oiLCJjb25kaXRpb25zIjpbeyJidWNrZXQiOiJldGFwaWRpcmVjdGJ1Y2tldHRlc3QifSx7ImtleSI6ImRpcmVjdF91cGxvYWRzLzU5MDI3NTNhLTZmYWQtNGU1OS05ZmI0LWU2NzdiN2QxNDBmNiJ9LHsic3VjY2Vzc19hY3Rpb25fc3RhdHVzIjoiMjAxIn0seyJ4LWFtei1jcmVkZW50aWFsIjoiYWNjZXNzS2V5MS8yMDE5MDMyOC91cy1lYXN0LTEvczMvYXdzNF9yZXF1ZXN0In0seyJ4LWFtei1hbGdvcml0aG0iOiJBV1M0LUhNQUMtU0hBMjU2In0seyJ4LWFtei1kYXRlIjoiMjAxOTAzMjhUMTM1OTM3WiJ9XX0=",
-                    "x-amz-credential": "accessKey1/20190328/us-east-1/s3/aws4_request",
+                    "policy": "eyJleHBpcmF0aW9uIjoiMjAxOS0wNC0yOVQwODozODo0MFoiLCJjb25kaXRpb25zIjpbeyJidWNrZXQiOiJldGFwaWRpcmVjdGJ1Y2tldHRlc3QifSx7ImtleSI6ImRpcmVjdF91cGxvYWRzLzllMDJkNDU0LTE5NDUtNDE0Yi1iMzhkLTkxNDI2OTJlYThhZiJ9LHsic3VjY2Vzc19hY3Rpb25fc3RhdHVzIjoiMjAxIn0seyJ4LWFtei1jcmVkZW50aWFsIjoiYWNjZXNzS2V5MS8yMDE5MDQyOS91cy1lYXN0LTEvczMvYXdzNF9yZXF1ZXN0In0seyJ4LWFtei1hbGdvcml0aG0iOiJBV1M0LUhNQUMtU0hBMjU2In0seyJ4LWFtei1kYXRlIjoiMjAxOTA0MjlUMDczODQwWiJ9XX0=",
+                    "x-amz-credential": "accessKey1/20190429/us-east-1/s3/aws4_request",
                     "x-amz-algorithm": "AWS4-HMAC-SHA256",
-                    "x-amz-date": "20190328T135937Z",
-                    "x-amz-signature": "405a98e42c48ddd7b204ef3e13d2e00e53071f5d3fdc96c5254872a7225d3992"
+                    "x-amz-date": "20190429T073840Z",
+                    "x-amz-signature": "67fddc7537f40837da7afef00189b1db1db177763a537c9cc5839f055d62a32e"
                   },
                   "url": "http://localhost:9000/etapidirectbuckettest"
                 }
@@ -161,14 +161,14 @@
               "properties": {
                 "uuid": {
                   "type": "string",
-                  "example": "1d51af80-de22-42b7-891b-0ad40e045d9f",
+                  "example": "98daa30f-046b-4325-b679-1815944bb368",
                   "description": "A unique ID produced by the client to refer to this command"
                 },
                 "data": {
                   "type": "array",
                   "example": [
                     {
-                      "uuid": "bbaf9cf8-a20a-4246-bff5-502e62b377a3",
+                      "uuid": "c5f756a5-59c3-4c9b-b457-e10b3bf41e64",
                       "command": "BuildClaim",
                       "data": {
                         "employment_details": {
@@ -196,7 +196,7 @@
                         "case_type": "Single",
                         "jurisdiction": "2",
                         "office_code": "22",
-                        "date_of_receipt": "2019-03-28T13:59:37+0000",
+                        "date_of_receipt": "2019-04-29T07:38:41+0000",
                         "other_known_claimant_names": "",
                         "discrimination_claims": [
 
@@ -217,7 +217,7 @@
                       }
                     },
                     {
-                      "uuid": "9981fee8-3894-4904-bc8e-dfe5add28740",
+                      "uuid": "b471f19e-cf1d-43e9-ba50-36d60081fd6b",
                       "command": "BuildPrimaryRespondent",
                       "data": {
                         "name": "dodgy_co",
@@ -253,7 +253,7 @@
                       }
                     },
                     {
-                      "uuid": "d9b5094a-db95-4d80-8eb4-f5c130918f07",
+                      "uuid": "4f57a754-8dba-4dc5-8e9a-2235aa5a2aa3",
                       "command": "BuildPrimaryClaimant",
                       "data": {
                         "title": "Mr",
@@ -277,7 +277,7 @@
                       }
                     },
                     {
-                      "uuid": "cdd235d9-d0dd-4ae2-8d7c-455b83f1d741",
+                      "uuid": "e2bdf387-1860-46a7-9701-c5268c80db81",
                       "command": "BuildSecondaryClaimants",
                       "data": [
                         {
@@ -303,7 +303,7 @@
                       ]
                     },
                     {
-                      "uuid": "fafe4b66-51dc-4ab3-bb9b-6e33c202a043",
+                      "uuid": "3cbcd3b2-23ec-437e-ad9d-98d88a39f9ee",
                       "command": "BuildSecondaryRespondents",
                       "data": [
                         {
@@ -341,7 +341,7 @@
                       ]
                     },
                     {
-                      "uuid": "b1227e5b-3a7e-4b31-a261-1fee4c6e795b",
+                      "uuid": "1addfce0-473c-44e8-813b-3b6599973f06",
                       "command": "BuildPrimaryRepresentative",
                       "data": {
                         "address_attributes": {
@@ -364,10 +364,10 @@
                       }
                     },
                     {
-                      "uuid": "4e9f7aaa-69e0-44f4-ac26-9cf3a2fee15d",
+                      "uuid": "6ec28766-6f34-4e82-8d37-9bbe5717fcbe",
                       "command": "BuildPdfFile",
                       "data": {
-                        "data_url": "http://localhost:9000/etapibuckettest/cEQjHxpSW34AzGPgC7vDwJMg?response-content-disposition=inline%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&response-content-type=application%2Fpdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190328T135938Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=92d038209c35ea2f16272f53e277c8041439b272c14d5070324ec417e969057e",
+                        "data_url": "http://localhost:9000/etapibuckettest/JZG5ZjkXTmvF4UKjvu1hZkLm?response-content-disposition=inline%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&response-content-type=application%2Fpdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190429T073841Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=998eb4e2241eb427b6dc17ee2190318290b7bbf77366a2450de9bd29d0033b94",
                         "data_from_key": null,
                         "filename": "et1_first_last.pdf",
                         "checksum": "ee2714b8b731a8c1e95dffaa33f89728"
@@ -414,17 +414,17 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "32c83292-20c5-4c6f-8f5a-6b2c9b0e13e0"
+                "x-example-value": "57a52b91-218f-4c20-bf16-d4e00041e1d5"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.316393"
+                "x-example-value": "0.197300"
               },
               "Content-Length": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "776"
+                "x-example-value": "949"
               }
             },
             "examples": {
@@ -433,7 +433,14 @@
                 "meta": {
                   "BuildClaim": {
                     "reference": "222000000100",
-                    "pdf_url": "http://localhost:9000/etapibuckettest/NQsjMtbD7L8RTsvVpHxjcuu4?response-content-disposition=attachment%3B%20filename%3D%22et1_atos_export.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_atos_export.pdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190328T135938Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=6bdb5767f06e8276ad1b175ca206f8e909ea3b6dbc9b4544d0618a45abc931f1"
+                    "office": {
+                      "name": "London Central",
+                      "code": 22,
+                      "telephone": "020 7273 8603",
+                      "address": "Victory House, 30-34 Kingsway, London WC2B 6EX",
+                      "email": "londoncentralet@hmcts.gsi.gov.uk"
+                    },
+                    "pdf_url": "http://localhost:9000/etapibuckettest/Rqoev3d6hP7KXtGk3e1QLXgv?response-content-disposition=attachment%3B%20filename%3D%22et1_first_last.pdf%22%3B%20filename%2A%3DUTF-8%27%27et1_first_last.pdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190429T073841Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=3632d8761ca3ed45201fce7390c23abb9881997868f6a2861adf5dfb5a2e4250"
                   },
                   "BuildPrimaryRespondent": {
                   },
@@ -448,7 +455,7 @@
                   "BuildPdfFile": {
                   }
                 },
-                "uuid": "1d51af80-de22-42b7-891b-0ad40e045d9f"
+                "uuid": "98daa30f-046b-4325-b679-1815944bb368"
               }
             }
           }
@@ -484,7 +491,7 @@
               "properties": {
                 "uuid": {
                   "type": "string",
-                  "example": "40da2c52-2f5f-4bea-ab3b-42183e7dc9ad",
+                  "example": "dd0da189-1cf4-423a-9850-31455394fc4f",
                   "description": "A unique ID produced by the client to refer to this command"
                 },
                 "data": {
@@ -524,7 +531,7 @@
               "ETag": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "W/\"edb64e48bc019955294286106997f8af\""
+                "x-example-value": "W/\"389d8cc7c8914f21f74ce1fea5e99d2c\""
               },
               "Cache-Control": {
                 "description": "",
@@ -534,12 +541,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "1bd05960-fb01-4624-b4e1-1afda416c7c4"
+                "x-example-value": "95ccaf97-fa6a-44b2-9a78-13464e85a074"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.039252"
+                "x-example-value": "0.028165"
               },
               "Content-Length": {
                 "description": "",
@@ -552,123 +559,15 @@
                 "status": "created",
                 "meta": {
                 },
-                "uuid": "40da2c52-2f5f-4bea-ab3b-42183e7dc9ad",
+                "uuid": "dd0da189-1cf4-423a-9850-31455394fc4f",
                 "data": {
-                  "reference": "222000139200",
+                  "reference": "222000036100",
                   "office": {
                     "code": "22",
                     "name": "London Central",
                     "address": "Victory House, 30-34 Kingsway, London WC2B 6EX",
                     "telephone": "020 7273 8603"
                   }
-                }
-              }
-            }
-          }
-        },
-        "deprecated": false,
-        "security": [
-
-        ]
-      }
-    },
-    "/api/v2/s3/create_signed_url": {
-      "post": {
-        "tags": [
-          "Signed S3 Resource"
-        ],
-        "summary": "",
-        "description": "",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "description": "",
-            "required": false,
-            "schema": {
-              "description": "",
-              "type": "object",
-              "properties": {
-                "uuid": {
-                  "type": "string",
-                  "example": "6e2c276e-bfc9-4ab2-b3d5-8a0367391db6",
-                  "description": "A unique ID produced by the client to refer to this command"
-                },
-                "data": {
-                  "type": "string",
-                  "description": "No data is required for this command"
-                },
-                "command": {
-                  "type": "string",
-                  "example": "CreateSignedS3FormData",
-                  "description": " command",
-                  "enum": [
-                    "SerialSequence"
-                  ]
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Create a signed s3 object suitable for use in a HTML form for use with direct upload",
-            "schema": {
-              "description": "",
-              "type": "object",
-              "properties": {
-              }
-            },
-            "headers": {
-              "Content-Type": {
-                "description": "",
-                "type": "string",
-                "x-example-value": "application/json; charset=utf-8"
-              },
-              "Cache-Control": {
-                "description": "",
-                "type": "string",
-                "x-example-value": "no-cache"
-              },
-              "X-Request-Id": {
-                "description": "",
-                "type": "string",
-                "x-example-value": "e08664cd-a88f-42ac-a1bb-7ddd87c870a7"
-              },
-              "X-Runtime": {
-                "description": "",
-                "type": "string",
-                "x-example-value": "0.026277"
-              },
-              "Content-Length": {
-                "description": "",
-                "type": "string",
-                "x-example-value": "904"
-              }
-            },
-            "examples": {
-              "application/json": {
-                "status": "accepted",
-                "meta": {
-                },
-                "uuid": "6e2c276e-bfc9-4ab2-b3d5-8a0367391db6",
-                "data": {
-                  "fields": {
-                    "key": "direct_uploads/10606769-d6eb-4703-9149-7c492220731a",
-                    "success_action_status": "201",
-                    "policy": "eyJleHBpcmF0aW9uIjoiMjAxOS0wMy0yOFQxNDo1OTozOVoiLCJjb25kaXRpb25zIjpbeyJidWNrZXQiOiJldGFwaWRpcmVjdGJ1Y2tldHRlc3QifSx7ImtleSI6ImRpcmVjdF91cGxvYWRzLzEwNjA2NzY5LWQ2ZWItNDcwMy05MTQ5LTdjNDkyMjIwNzMxYSJ9LHsic3VjY2Vzc19hY3Rpb25fc3RhdHVzIjoiMjAxIn0seyJ4LWFtei1jcmVkZW50aWFsIjoiYWNjZXNzS2V5MS8yMDE5MDMyOC91cy1lYXN0LTEvczMvYXdzNF9yZXF1ZXN0In0seyJ4LWFtei1hbGdvcml0aG0iOiJBV1M0LUhNQUMtU0hBMjU2In0seyJ4LWFtei1kYXRlIjoiMjAxOTAzMjhUMTM1OTM5WiJ9XX0=",
-                    "x-amz-credential": "accessKey1/20190328/us-east-1/s3/aws4_request",
-                    "x-amz-algorithm": "AWS4-HMAC-SHA256",
-                    "x-amz-date": "20190328T135939Z",
-                    "x-amz-signature": "5572f003323fbccefe0b2a9fb0601da2b6b179171f8c747e3ee14082c619ea91"
-                  },
-                  "url": "http://localhost:9000/etapidirectbuckettest"
                 }
               }
             }
@@ -705,7 +604,7 @@
               "properties": {
                 "uuid": {
                   "type": "string",
-                  "example": "ec12440a-3439-4ec9-b1fa-2d85f89c242a",
+                  "example": "a210b3e4-5622-49ce-89b3-ee06d276a12d",
                   "description": "A unique ID produced by the client to refer to this command"
                 },
                 "data": {
@@ -757,7 +656,7 @@
               "ETag": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "W/\"5d084ac4b42d969f337defe6b9e00506\""
+                "x-example-value": "W/\"37948e59c7d27593fd85b955bae21fde\""
               },
               "Cache-Control": {
                 "description": "",
@@ -767,12 +666,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "6ad2f15a-5a6c-4821-981d-293c8ee4442e"
+                "x-example-value": "3812ec2c-3f0a-4f9b-89df-300212c8fdc7"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.044661"
+                "x-example-value": "0.033990"
               },
               "Content-Length": {
                 "description": "",
@@ -783,7 +682,7 @@
             "examples": {
               "application/json": {
                 "status": "accepted",
-                "uuid": "ec12440a-3439-4ec9-b1fa-2d85f89c242a"
+                "uuid": "a210b3e4-5622-49ce-89b3-ee06d276a12d"
               }
             }
           }
@@ -844,12 +743,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "e1773741-778a-4dcd-a932-3a59ba832260"
+                "x-example-value": "68327b9f-393e-4ade-8b9a-3f7fe2e52513"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.467326"
+                "x-example-value": "0.410589"
               },
               "Content-Length": {
                 "description": "",
@@ -895,12 +794,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "7ee185a1-3c2f-479c-a338-ca17a4f85af7"
+                "x-example-value": "2ad66bb0-5461-4695-aedf-03c17f00503a"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.023548"
+                "x-example-value": "0.018898"
               },
               "Content-Length": {
                 "description": "",
@@ -936,12 +835,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "04a39f39-bbee-425c-9896-0a31b7491395"
+                "x-example-value": "ee887d2f-4144-4a5a-9b94-8034f1f2208d"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.024544"
+                "x-example-value": "0.019383"
               },
               "Content-Length": {
                 "description": "",
@@ -982,12 +881,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "05298e0d-095a-49e4-b825-13576a3b6e87"
+                "x-example-value": "8fa53fc1-c835-495d-9484-23e93a47e816"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.029221"
+                "x-example-value": "0.016098"
               },
               "Content-Length": {
                 "description": "",
@@ -1038,14 +937,14 @@
               "properties": {
                 "uuid": {
                   "type": "string",
-                  "example": "b15b0615-0ec8-491f-936f-79b28c6c6769",
+                  "example": "4d765cb7-72fb-4363-a7a9-5203f9dea9b6",
                   "description": "A unique ID produced by the client to refer to this command"
                 },
                 "data": {
                   "type": "array",
                   "example": [
                     {
-                      "uuid": "513e7fe8-a7cf-42c2-a051-ebec1aca8e35",
+                      "uuid": "9d08acf1-5a58-4418-87f9-956d56c2eb49",
                       "command": "BuildResponse",
                       "data": {
                         "additional_information_key": null,
@@ -1081,7 +980,7 @@
                       }
                     },
                     {
-                      "uuid": "f9453014-5032-499a-b489-ec81b1b0f849",
+                      "uuid": "b6ab94c4-6349-4374-adc7-a1354e34ff87",
                       "command": "BuildRespondent",
                       "data": {
                         "name": "dodgy_co",
@@ -1117,7 +1016,7 @@
                       }
                     },
                     {
-                      "uuid": "0af496ff-e2de-4056-88da-6cb727868bd8",
+                      "uuid": "e645474d-7f19-4218-8e7d-f8ccff66c583",
                       "command": "BuildRepresentative",
                       "data": {
                         "address_attributes": {
@@ -1180,12 +1079,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "9b322791-0741-42c4-b28b-2ac76542b8f8"
+                "x-example-value": "568b65c7-f399-41a3-af94-874f3c6ad004"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.104303"
+                "x-example-value": "0.073830"
               },
               "Content-Length": {
                 "description": "",
@@ -1198,18 +1097,18 @@
                 "status": "accepted",
                 "meta": {
                   "BuildResponse": {
-                    "submitted_at": "2019-03-28T13:59:39.859Z",
-                    "reference": "142000139300",
+                    "submitted_at": "2019-04-29T07:38:42.753Z",
+                    "reference": "142000036200",
                     "office_address": "Bristol Civil and Family Justice Centre, 2 Redcliff Street, Bristol, BS1 6GR",
                     "office_phone_number": "0117 929 8261",
-                    "pdf_url": "http://localhost:9000/etapibuckettest/pJGTknKbjvH5RXLu3uUpZnwK?response-content-disposition=attachment%3B%20filename%3D%22et3_atos_export.pdf%22%3B%20filename%2A%3DUTF-8%27%27et3_atos_export.pdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190328T135939Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=bc63f7a890f2472927d75d56737959d181709e921fcbf6b96df87c3bf8e579c5"
+                    "pdf_url": "http://localhost:9000/etapibuckettest/hXDJC3msVKrENEm7LL2WXo6w?response-content-disposition=attachment%3B%20filename%3D%22et3_atos_export.pdf%22%3B%20filename%2A%3DUTF-8%27%27et3_atos_export.pdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190429T073842Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=0f414dae6d7844385a17b82af6cf2f8f4309f36965f7a757d1e4a6c3b64a8760"
                   },
                   "BuildRespondent": {
                   },
                   "BuildRepresentative": {
                   }
                 },
-                "uuid": "b15b0615-0ec8-491f-936f-79b28c6c6769"
+                "uuid": "4d765cb7-72fb-4363-a7a9-5203f9dea9b6"
               }
             }
           },
@@ -1235,12 +1134,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "cddef9b1-194b-44a8-929f-593577cc77e4"
+                "x-example-value": "c31d38de-07c6-4087-9e2d-8e27b935d868"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.019326"
+                "x-example-value": "0.009365"
               },
               "Content-Length": {
                 "description": "",
@@ -1251,7 +1150,7 @@
             "examples": {
               "application/json": {
                 "status": "not_accepted",
-                "uuid": "0cb29b8f-4566-4471-88af-4ab7d8c4e705",
+                "uuid": "2b8f4ab3-1fc2-449c-9bcb-c6f2c40f06ae",
                 "errors": [
                   {
                     "status": 422,
@@ -1260,7 +1159,7 @@
                     "detail": "Invalid case number",
                     "source": "/data/0/case_number",
                     "command": "BuildResponse",
-                    "uuid": "42d5d0e1-2d2b-4313-8976-5cd1f9eb77c1"
+                    "uuid": "19fe5efe-e3ed-4712-a900-810ee10198cd"
                   }
                 ]
               }
@@ -1298,14 +1197,14 @@
               "properties": {
                 "uuid": {
                   "type": "string",
-                  "example": "de290aea-f37d-4e1e-b7ca-440da73ff7ed",
+                  "example": "15736d0a-054a-460c-8644-61db149b5255",
                   "description": "A unique ID produced by the client to refer to this command"
                 },
                 "data": {
                   "type": "object",
                   "example": {
                     "data_url": null,
-                    "data_from_key": "g7cg5sRxVVNZvHYqQt2ZHo7q",
+                    "data_from_key": "uazZKo37yaN8zNQfPmo45eQy",
                     "filename": "simple_user_with_csv_group_claims.csv",
                     "checksum": "7ac66d9f4af3b498e4cf7b9430974618"
                   },
@@ -1341,7 +1240,7 @@
               "ETag": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "W/\"a6da791a5c53a2e659f5fbe54756220a\""
+                "x-example-value": "W/\"1bd760328587e81211c7012271e3edf9\""
               },
               "Cache-Control": {
                 "description": "",
@@ -1351,12 +1250,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "f5f6722f-bb2a-4bf7-ab64-37247e049976"
+                "x-example-value": "9cdb330d-52a8-41b1-91d5-06f62a98fd71"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.044769"
+                "x-example-value": "0.075323"
               },
               "Content-Length": {
                 "description": "",
@@ -1367,7 +1266,7 @@
             "examples": {
               "application/json": {
                 "status": "accepted",
-                "uuid": "de290aea-f37d-4e1e-b7ca-440da73ff7ed"
+                "uuid": "15736d0a-054a-460c-8644-61db149b5255"
               }
             }
           },
@@ -1393,12 +1292,12 @@
               "X-Request-Id": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "705a0a79-a4e1-4b14-b3e4-806743402073"
+                "x-example-value": "5308c092-5ecd-454d-8a6d-9bfbe86256c9"
               },
               "X-Runtime": {
                 "description": "",
                 "type": "string",
-                "x-example-value": "0.020695"
+                "x-example-value": "0.065248"
               },
               "Content-Length": {
                 "description": "",
@@ -1409,7 +1308,7 @@
             "examples": {
               "application/json": {
                 "status": "not_accepted",
-                "uuid": "5cfcb2fd-72cb-41e6-81d6-cb160dcc7611",
+                "uuid": "fd628e11-bba9-4623-bb05-cb88eb895cf4",
                 "errors": [
                   {
                     "status": 422,
@@ -1418,7 +1317,7 @@
                     "detail": "is invalid",
                     "source": "/data_from_key/0/date_of_birth",
                     "command": "ValidateClaimantsFile",
-                    "uuid": "5cfcb2fd-72cb-41e6-81d6-cb160dcc7611"
+                    "uuid": "fd628e11-bba9-4623-bb05-cb88eb895cf4"
                   },
                   {
                     "status": 422,
@@ -1427,7 +1326,7 @@
                     "detail": "is not included in the list",
                     "source": "/data_from_key/1/title",
                     "command": "ValidateClaimantsFile",
-                    "uuid": "5cfcb2fd-72cb-41e6-81d6-cb160dcc7611"
+                    "uuid": "fd628e11-bba9-4623-bb05-cb88eb895cf4"
                   }
                 ]
               }
@@ -1457,10 +1356,6 @@
     {
       "name": "Claim Reference",
       "description": "Claim Reference resource"
-    },
-    {
-      "name": "Signed S3 Resource",
-      "description": "Signed S3 resource"
     },
     {
       "name": "Diversity response",

--- a/docs/api/response/response_not_created_-_this_example_shows_invalid_case_number_due_to_the_office_code_not_being_correct.md
+++ b/docs/api/response/response_not_created_-_this_example_shows_invalid_case_number_due_to_the_office_code_not_being_correct.md
@@ -30,11 +30,11 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "0cb29b8f-4566-4471-88af-4ab7d8c4e705",
+  "uuid": "2b8f4ab3-1fc2-449c-9bcb-c6f2c40f06ae",
   "command": "SerialSequence",
   "data": [
     {
-      "uuid": "42d5d0e1-2d2b-4313-8976-5cd1f9eb77c1",
+      "uuid": "19fe5efe-e3ed-4712-a900-810ee10198cd",
       "command": "BuildResponse",
       "data": {
         "additional_information_key": null,
@@ -70,7 +70,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "a3e3afbb-5b91-413d-8c1b-8f3240bb8c65",
+      "uuid": "b5bb2567-9022-43a6-8550-0a88a230105b",
       "command": "BuildRespondent",
       "data": {
         "name": "dodgy_co",
@@ -111,11 +111,11 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/respondents/build_response&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;0cb29b8f-4566-4471-88af-4ab7d8c4e705&quot;,
+  &quot;uuid&quot;: &quot;2b8f4ab3-1fc2-449c-9bcb-c6f2c40f06ae&quot;,
   &quot;command&quot;: &quot;SerialSequence&quot;,
   &quot;data&quot;: [
     {
-      &quot;uuid&quot;: &quot;42d5d0e1-2d2b-4313-8976-5cd1f9eb77c1&quot;,
+      &quot;uuid&quot;: &quot;19fe5efe-e3ed-4712-a900-810ee10198cd&quot;,
       &quot;command&quot;: &quot;BuildResponse&quot;,
       &quot;data&quot;: {
         &quot;additional_information_key&quot;: null,
@@ -151,7 +151,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;a3e3afbb-5b91-413d-8c1b-8f3240bb8c65&quot;,
+      &quot;uuid&quot;: &quot;b5bb2567-9022-43a6-8550-0a88a230105b&quot;,
       &quot;command&quot;: &quot;BuildRespondent&quot;,
       &quot;data&quot;: {
         &quot;name&quot;: &quot;dodgy_co&quot;,
@@ -199,8 +199,8 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: cddef9b1-194b-44a8-929f-593577cc77e4
-X-Runtime: 0.019326
+X-Request-Id: c31d38de-07c6-4087-9e2d-8e27b935d868
+X-Runtime: 0.009365
 Content-Length: 290</pre>
 
 #### Status
@@ -209,4 +209,4 @@ Content-Length: 290</pre>
 
 #### Body
 
-<pre>{"status":"not_accepted","uuid":"0cb29b8f-4566-4471-88af-4ab7d8c4e705","errors":[{"status":422,"code":"invalid_office_code","title":"Invalid case number","detail":"Invalid case number","source":"/data/0/case_number","command":"BuildResponse","uuid":"42d5d0e1-2d2b-4313-8976-5cd1f9eb77c1"}]}</pre>
+<pre>{"status":"not_accepted","uuid":"2b8f4ab3-1fc2-449c-9bcb-c6f2c40f06ae","errors":[{"status":422,"code":"invalid_office_code","title":"Invalid case number","detail":"Invalid case number","source":"/data/0/case_number","command":"BuildResponse","uuid":"19fe5efe-e3ed-4712-a900-810ee10198cd"}]}</pre>

--- a/docs/api/response/response_successfully_created.md
+++ b/docs/api/response/response_successfully_created.md
@@ -30,11 +30,11 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "b15b0615-0ec8-491f-936f-79b28c6c6769",
+  "uuid": "4d765cb7-72fb-4363-a7a9-5203f9dea9b6",
   "command": "SerialSequence",
   "data": [
     {
-      "uuid": "513e7fe8-a7cf-42c2-a051-ebec1aca8e35",
+      "uuid": "9d08acf1-5a58-4418-87f9-956d56c2eb49",
       "command": "BuildResponse",
       "data": {
         "additional_information_key": null,
@@ -70,7 +70,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "f9453014-5032-499a-b489-ec81b1b0f849",
+      "uuid": "b6ab94c4-6349-4374-adc7-a1354e34ff87",
       "command": "BuildRespondent",
       "data": {
         "name": "dodgy_co",
@@ -106,7 +106,7 @@ Cookie: </pre>
       }
     },
     {
-      "uuid": "0af496ff-e2de-4056-88da-6cb727868bd8",
+      "uuid": "e645474d-7f19-4218-8e7d-f8ccff66c583",
       "command": "BuildRepresentative",
       "data": {
         "address_attributes": {
@@ -134,11 +134,11 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/respondents/build_response&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;b15b0615-0ec8-491f-936f-79b28c6c6769&quot;,
+  &quot;uuid&quot;: &quot;4d765cb7-72fb-4363-a7a9-5203f9dea9b6&quot;,
   &quot;command&quot;: &quot;SerialSequence&quot;,
   &quot;data&quot;: [
     {
-      &quot;uuid&quot;: &quot;513e7fe8-a7cf-42c2-a051-ebec1aca8e35&quot;,
+      &quot;uuid&quot;: &quot;9d08acf1-5a58-4418-87f9-956d56c2eb49&quot;,
       &quot;command&quot;: &quot;BuildResponse&quot;,
       &quot;data&quot;: {
         &quot;additional_information_key&quot;: null,
@@ -174,7 +174,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;f9453014-5032-499a-b489-ec81b1b0f849&quot;,
+      &quot;uuid&quot;: &quot;b6ab94c4-6349-4374-adc7-a1354e34ff87&quot;,
       &quot;command&quot;: &quot;BuildRespondent&quot;,
       &quot;data&quot;: {
         &quot;name&quot;: &quot;dodgy_co&quot;,
@@ -210,7 +210,7 @@ Cookie: </pre>
       }
     },
     {
-      &quot;uuid&quot;: &quot;0af496ff-e2de-4056-88da-6cb727868bd8&quot;,
+      &quot;uuid&quot;: &quot;e645474d-7f19-4218-8e7d-f8ccff66c583&quot;,
       &quot;command&quot;: &quot;BuildRepresentative&quot;,
       &quot;data&quot;: {
         &quot;address_attributes&quot;: {
@@ -245,8 +245,8 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: 9b322791-0741-42c4-b28b-2ac76542b8f8
-X-Runtime: 0.104303
+X-Request-Id: 568b65c7-f399-41a3-af94-874f3c6ad004
+X-Runtime: 0.073830
 Content-Length: 837</pre>
 
 #### Status
@@ -255,4 +255,4 @@ Content-Length: 837</pre>
 
 #### Body
 
-<pre>{"status":"accepted","meta":{"BuildResponse":{"submitted_at":"2019-03-28T13:59:39.859Z","reference":"142000139300","office_address":"Bristol Civil and Family Justice Centre, 2 Redcliff Street, Bristol, BS1 6GR","office_phone_number":"0117 929 8261","pdf_url":"http://localhost:9000/etapibuckettest/pJGTknKbjvH5RXLu3uUpZnwK?response-content-disposition=attachment%3B%20filename%3D%22et3_atos_export.pdf%22%3B%20filename%2A%3DUTF-8%27%27et3_atos_export.pdf\u0026X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=accessKey1%2F20190328%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20190328T135939Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=bc63f7a890f2472927d75d56737959d181709e921fcbf6b96df87c3bf8e579c5"},"BuildRespondent":{},"BuildRepresentative":{}},"uuid":"b15b0615-0ec8-491f-936f-79b28c6c6769"}</pre>
+<pre>{"status":"accepted","meta":{"BuildResponse":{"submitted_at":"2019-04-29T07:38:42.753Z","reference":"142000036200","office_address":"Bristol Civil and Family Justice Centre, 2 Redcliff Street, Bristol, BS1 6GR","office_phone_number":"0117 929 8261","pdf_url":"http://localhost:9000/etapibuckettest/hXDJC3msVKrENEm7LL2WXo6w?response-content-disposition=attachment%3B%20filename%3D%22et3_atos_export.pdf%22%3B%20filename%2A%3DUTF-8%27%27et3_atos_export.pdf\u0026X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=accessKey1%2F20190429%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20190429T073842Z\u0026X-Amz-Expires=3600\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=0f414dae6d7844385a17b82af6cf2f8f4309f36965f7a757d1e4a6c3b64a8760"},"BuildRespondent":{},"BuildRepresentative":{}},"uuid":"4d765cb7-72fb-4363-a7a9-5203f9dea9b6"}</pre>

--- a/docs/api/validate_claimants_file/claimants_file_invalid_-_due_to_a_missing_column.md
+++ b/docs/api/validate_claimants_file/claimants_file_invalid_-_due_to_a_missing_column.md
@@ -30,11 +30,11 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "0082e979-5c7c-451f-8376-5d5088a3ba5a",
+  "uuid": "4ebe1a1d-7634-44db-b943-12c69d35f002",
   "command": "ValidateClaimantsFile",
   "data": {
     "data_url": null,
-    "data_from_key": "22iqceY6c2VdbbXmroRNiZ22",
+    "data_from_key": "An9RT4iSvnEatP5hVGCbWLQp",
     "filename": "simple_user_with_csv_group_claims.csv",
     "checksum": "7ac66d9f4af3b498e4cf7b9430974618"
   }
@@ -43,11 +43,11 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/validate&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;0082e979-5c7c-451f-8376-5d5088a3ba5a&quot;,
+  &quot;uuid&quot;: &quot;4ebe1a1d-7634-44db-b943-12c69d35f002&quot;,
   &quot;command&quot;: &quot;ValidateClaimantsFile&quot;,
   &quot;data&quot;: {
     &quot;data_url&quot;: null,
-    &quot;data_from_key&quot;: &quot;22iqceY6c2VdbbXmroRNiZ22&quot;,
+    &quot;data_from_key&quot;: &quot;An9RT4iSvnEatP5hVGCbWLQp&quot;,
     &quot;filename&quot;: &quot;simple_user_with_csv_group_claims.csv&quot;,
     &quot;checksum&quot;: &quot;7ac66d9f4af3b498e4cf7b9430974618&quot;
   }
@@ -63,8 +63,8 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: 0fa8a047-d991-4829-8cc7-ff0cfa110160
-X-Runtime: 0.038861
+X-Request-Id: c1936630-f9b4-40cf-89aa-296602180f36
+X-Runtime: 0.061872
 Content-Length: 324</pre>
 
 #### Status
@@ -73,4 +73,4 @@ Content-Length: 324</pre>
 
 #### Body
 
-<pre>{"status":"not_accepted","uuid":"0082e979-5c7c-451f-8376-5d5088a3ba5a","errors":[{"status":422,"code":"invalid_columns","title":"file does not contain the correct columns","detail":"file does not contain the correct columns","source":"/base","command":"ValidateClaimantsFile","uuid":"0082e979-5c7c-451f-8376-5d5088a3ba5a"}]}</pre>
+<pre>{"status":"not_accepted","uuid":"4ebe1a1d-7634-44db-b943-12c69d35f002","errors":[{"status":422,"code":"invalid_columns","title":"file does not contain the correct columns","detail":"file does not contain the correct columns","source":"/base","command":"ValidateClaimantsFile","uuid":"4ebe1a1d-7634-44db-b943-12c69d35f002"}]}</pre>

--- a/docs/api/validate_claimants_file/claimants_file_invalid_-_due_to_a_missing_file.md
+++ b/docs/api/validate_claimants_file/claimants_file_invalid_-_due_to_a_missing_file.md
@@ -30,7 +30,7 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "86726675-7618-4f80-8df3-cc357f672842",
+  "uuid": "971c1815-471b-4c23-ac6e-5a6997575597",
   "command": "ValidateClaimantsFile",
   "data": {
     "data_url": null,
@@ -43,7 +43,7 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/validate&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;86726675-7618-4f80-8df3-cc357f672842&quot;,
+  &quot;uuid&quot;: &quot;971c1815-471b-4c23-ac6e-5a6997575597&quot;,
   &quot;command&quot;: &quot;ValidateClaimantsFile&quot;,
   &quot;data&quot;: {
     &quot;data_url&quot;: null,
@@ -63,8 +63,8 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: f0007a35-8ae8-4b32-be40-1b77c8cb1f06
-X-Runtime: 0.010712
+X-Request-Id: 89ee6861-e428-4967-8bd0-c99348759d41
+X-Runtime: 0.028456
 Content-Length: 269</pre>
 
 #### Status
@@ -73,4 +73,4 @@ Content-Length: 269</pre>
 
 #### Body
 
-<pre>{"status":"not_accepted","uuid":"86726675-7618-4f80-8df3-cc357f672842","errors":[{"status":422,"code":"missing_file","title":"file is missing","detail":"file is missing","source":"/base","command":"ValidateClaimantsFile","uuid":"86726675-7618-4f80-8df3-cc357f672842"}]}</pre>
+<pre>{"status":"not_accepted","uuid":"971c1815-471b-4c23-ac6e-5a6997575597","errors":[{"status":422,"code":"missing_file","title":"file is missing","detail":"file is missing","source":"/base","command":"ValidateClaimantsFile","uuid":"971c1815-471b-4c23-ac6e-5a6997575597"}]}</pre>

--- a/docs/api/validate_claimants_file/claimants_file_invalid_-_due_to_an_empty_file.md
+++ b/docs/api/validate_claimants_file/claimants_file_invalid_-_due_to_an_empty_file.md
@@ -30,11 +30,11 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "1e059ba9-b1b2-4f3f-baf7-db8260008e0c",
+  "uuid": "c9f82c91-2b93-4474-95de-dbd8f9921c44",
   "command": "ValidateClaimantsFile",
   "data": {
     "data_url": null,
-    "data_from_key": "maVEtMPXgZSgCzAjUtwFaU9r",
+    "data_from_key": "K11VbGzbC4p8vPdSwHHvE3fy",
     "filename": "simple_user_with_csv_group_claims.csv",
     "checksum": "7ac66d9f4af3b498e4cf7b9430974618"
   }
@@ -43,11 +43,11 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/validate&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;1e059ba9-b1b2-4f3f-baf7-db8260008e0c&quot;,
+  &quot;uuid&quot;: &quot;c9f82c91-2b93-4474-95de-dbd8f9921c44&quot;,
   &quot;command&quot;: &quot;ValidateClaimantsFile&quot;,
   &quot;data&quot;: {
     &quot;data_url&quot;: null,
-    &quot;data_from_key&quot;: &quot;maVEtMPXgZSgCzAjUtwFaU9r&quot;,
+    &quot;data_from_key&quot;: &quot;K11VbGzbC4p8vPdSwHHvE3fy&quot;,
     &quot;filename&quot;: &quot;simple_user_with_csv_group_claims.csv&quot;,
     &quot;checksum&quot;: &quot;7ac66d9f4af3b498e4cf7b9430974618&quot;
   }
@@ -63,8 +63,8 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: b9c388f9-32b6-4ee5-a52a-0734eb4272b2
-X-Runtime: 0.016410
+X-Request-Id: 6c04dcd5-7638-4c61-a72f-137d0ddb56d6
+X-Runtime: 0.040682
 Content-Length: 263</pre>
 
 #### Status
@@ -73,4 +73,4 @@ Content-Length: 263</pre>
 
 #### Body
 
-<pre>{"status":"not_accepted","uuid":"1e059ba9-b1b2-4f3f-baf7-db8260008e0c","errors":[{"status":422,"code":"empty_file","title":"file is empty","detail":"file is empty","source":"/base","command":"ValidateClaimantsFile","uuid":"1e059ba9-b1b2-4f3f-baf7-db8260008e0c"}]}</pre>
+<pre>{"status":"not_accepted","uuid":"c9f82c91-2b93-4474-95de-dbd8f9921c44","errors":[{"status":422,"code":"empty_file","title":"file is empty","detail":"file is empty","source":"/base","command":"ValidateClaimantsFile","uuid":"c9f82c91-2b93-4474-95de-dbd8f9921c44"}]}</pre>

--- a/docs/api/validate_claimants_file/claimants_file_invalid_-_due_to_invalid_rows.md
+++ b/docs/api/validate_claimants_file/claimants_file_invalid_-_due_to_invalid_rows.md
@@ -30,11 +30,11 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "5cfcb2fd-72cb-41e6-81d6-cb160dcc7611",
+  "uuid": "fd628e11-bba9-4623-bb05-cb88eb895cf4",
   "command": "ValidateClaimantsFile",
   "data": {
     "data_url": null,
-    "data_from_key": "o61VM8x1r5qFomjCwjpnp9Kz",
+    "data_from_key": "TB2xTurAHZs1gfraDNGTKdiR",
     "filename": "simple_user_with_csv_group_claims_multiple_errors.csv",
     "checksum": "7ac66d9f4af3b498e4cf7b9430974618"
   }
@@ -43,11 +43,11 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/validate&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;5cfcb2fd-72cb-41e6-81d6-cb160dcc7611&quot;,
+  &quot;uuid&quot;: &quot;fd628e11-bba9-4623-bb05-cb88eb895cf4&quot;,
   &quot;command&quot;: &quot;ValidateClaimantsFile&quot;,
   &quot;data&quot;: {
     &quot;data_url&quot;: null,
-    &quot;data_from_key&quot;: &quot;o61VM8x1r5qFomjCwjpnp9Kz&quot;,
+    &quot;data_from_key&quot;: &quot;TB2xTurAHZs1gfraDNGTKdiR&quot;,
     &quot;filename&quot;: &quot;simple_user_with_csv_group_claims_multiple_errors.csv&quot;,
     &quot;checksum&quot;: &quot;7ac66d9f4af3b498e4cf7b9430974618&quot;
   }
@@ -63,8 +63,8 @@ Cookie: </pre>
 
 <pre>Content-Type: application/json; charset=utf-8
 Cache-Control: no-cache
-X-Request-Id: 705a0a79-a4e1-4b14-b3e4-806743402073
-X-Runtime: 0.020695
+X-Request-Id: 5308c092-5ecd-454d-8a6d-9bfbe86256c9
+X-Runtime: 0.065248
 Content-Length: 504</pre>
 
 #### Status
@@ -73,4 +73,4 @@ Content-Length: 504</pre>
 
 #### Body
 
-<pre>{"status":"not_accepted","uuid":"5cfcb2fd-72cb-41e6-81d6-cb160dcc7611","errors":[{"status":422,"code":"invalid","title":"is invalid","detail":"is invalid","source":"/data_from_key/0/date_of_birth","command":"ValidateClaimantsFile","uuid":"5cfcb2fd-72cb-41e6-81d6-cb160dcc7611"},{"status":422,"code":"inclusion","title":"is not included in the list","detail":"is not included in the list","source":"/data_from_key/1/title","command":"ValidateClaimantsFile","uuid":"5cfcb2fd-72cb-41e6-81d6-cb160dcc7611"}]}</pre>
+<pre>{"status":"not_accepted","uuid":"fd628e11-bba9-4623-bb05-cb88eb895cf4","errors":[{"status":422,"code":"invalid","title":"is invalid","detail":"is invalid","source":"/data_from_key/0/date_of_birth","command":"ValidateClaimantsFile","uuid":"fd628e11-bba9-4623-bb05-cb88eb895cf4"},{"status":422,"code":"inclusion","title":"is not included in the list","detail":"is not included in the list","source":"/data_from_key/1/title","command":"ValidateClaimantsFile","uuid":"fd628e11-bba9-4623-bb05-cb88eb895cf4"}]}</pre>

--- a/docs/api/validate_claimants_file/claimants_file_successfully_validated.md
+++ b/docs/api/validate_claimants_file/claimants_file_successfully_validated.md
@@ -30,11 +30,11 @@ Cookie: </pre>
 #### Body
 
 <pre>{
-  "uuid": "de290aea-f37d-4e1e-b7ca-440da73ff7ed",
+  "uuid": "15736d0a-054a-460c-8644-61db149b5255",
   "command": "ValidateClaimantsFile",
   "data": {
     "data_url": null,
-    "data_from_key": "g7cg5sRxVVNZvHYqQt2ZHo7q",
+    "data_from_key": "uazZKo37yaN8zNQfPmo45eQy",
     "filename": "simple_user_with_csv_group_claims.csv",
     "checksum": "7ac66d9f4af3b498e4cf7b9430974618"
   }
@@ -43,11 +43,11 @@ Cookie: </pre>
 #### cURL
 
 <pre class="request">curl &quot;http://localhost:3000/api/v2/validate&quot; -d &#39;{
-  &quot;uuid&quot;: &quot;de290aea-f37d-4e1e-b7ca-440da73ff7ed&quot;,
+  &quot;uuid&quot;: &quot;15736d0a-054a-460c-8644-61db149b5255&quot;,
   &quot;command&quot;: &quot;ValidateClaimantsFile&quot;,
   &quot;data&quot;: {
     &quot;data_url&quot;: null,
-    &quot;data_from_key&quot;: &quot;g7cg5sRxVVNZvHYqQt2ZHo7q&quot;,
+    &quot;data_from_key&quot;: &quot;uazZKo37yaN8zNQfPmo45eQy&quot;,
     &quot;filename&quot;: &quot;simple_user_with_csv_group_claims.csv&quot;,
     &quot;checksum&quot;: &quot;7ac66d9f4af3b498e4cf7b9430974618&quot;
   }
@@ -62,10 +62,10 @@ Cookie: </pre>
 #### Headers
 
 <pre>Content-Type: application/json; charset=utf-8
-ETag: W/&quot;a6da791a5c53a2e659f5fbe54756220a&quot;
+ETag: W/&quot;1bd760328587e81211c7012271e3edf9&quot;
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: f5f6722f-bb2a-4bf7-ab64-37247e049976
-X-Runtime: 0.044769
+X-Request-Id: 9cdb330d-52a8-41b1-91d5-06f62a98fd71
+X-Runtime: 0.075323
 Content-Length: 67</pre>
 
 #### Status
@@ -74,4 +74,4 @@ Content-Length: 67</pre>
 
 #### Body
 
-<pre>{"status":"accepted","uuid":"de290aea-f37d-4e1e-b7ca-440da73ff7ed"}</pre>
+<pre>{"status":"accepted","uuid":"15736d0a-054a-460c-8644-61db149b5255"}</pre>

--- a/spec/commands/assign_office_to_claim_command_spec.rb
+++ b/spec/commands/assign_office_to_claim_command_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe AssignOfficeToClaimCommand do
+  subject(:command) { described_class.new(uuid: uuid, data: {}, office_service: mock_office_service) }
+
+  let(:uuid) { SecureRandom.uuid }
+  let(:root_object) { build(:claim, :example_data) }
+  let(:example_office) { instance_double('Office', code: 65, name: 'Example Office', telephone: '01234 567890', address: '1 Liverpool Street', email: 'info@exampleoffice.com') }
+  let(:mock_office_service) { class_double('OfficeService', lookup_postcode: example_office) }
+
+  include_context 'with disabled event handlers'
+
+  describe '#apply' do
+    it 'adds the office data to the meta' do
+      # Arrange
+      meta = {}
+
+      # Act
+      command.apply(root_object, meta: meta)
+
+      # Assert
+      expect(meta).to include office: a_hash_including(code: 65, name: 'Example Office', telephone: '01234 567890', address: '1 Liverpool Street', email: 'info@exampleoffice.com')
+    end
+  end
+end

--- a/spec/commands/assign_reference_to_claim_command_spec.rb
+++ b/spec/commands/assign_reference_to_claim_command_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe AssignReferenceToClaimCommand do
+  subject(:command) { described_class.new(uuid: uuid, data: {}, reference_service: mock_reference_service) }
+
+  let(:uuid) { SecureRandom.uuid }
+  let(:root_object) { build(:claim, :example_data, office_code: 32, reference: nil) }
+  let(:mock_reference_service) { class_double('ReferenceService', next_number: 20000005) }
+
+  include_context 'with disabled event handlers'
+
+  describe '#apply' do
+    context 'using a claim with no reference' do
+      it 'adds the reference to the meta' do
+        # Arrange
+        meta = {}
+
+        # Act
+        command.apply(root_object, meta: meta)
+
+        # Assert
+        expect(meta).to include reference: '322000000500'
+      end
+    end
+
+    context 'using a claim with existing reference' do
+      let(:root_object) { build(:claim, :example_data, office_code: 32, reference: '222000000200') }
+      it 'adds the existing reference to the meta' do
+        # Arrange
+        meta = {}
+
+        # Act
+        command.apply(root_object, meta: meta)
+
+        # Assert
+        expect(meta).to include reference: '222000000200'
+      end
+    end
+  end
+end

--- a/spec/commands/create_claim_command_spec.rb
+++ b/spec/commands/create_claim_command_spec.rb
@@ -1,0 +1,290 @@
+require 'rails_helper'
+
+RSpec.describe CreateClaimCommand do
+  subject(:command) { described_class.new(**data) }
+
+  let(:uuid) { SecureRandom.uuid }
+  let(:data) { build(:json_build_claim_commands, :with_csv, :with_rtf, :with_pdf).as_json }
+  let(:root_object) { build(:claim) }
+  let(:example_meta_hash) { { example: :meta } }
+  let(:mock_commands) { OpenStruct.new }
+  let(:mock_command_classes) { OpenStruct.new }
+
+  shared_context 'with mocked sub commands' do
+    before do
+      singular_commands = [:build_claim, :build_primary_respondent, :build_primary_claimant,
+                  :build_primary_representative, :build_pdf_file, :build_claimants_file, :build_claim_details_file, :assign_reference_to_claim,
+                  :assign_office_to_claim, :pre_allocate_pdf_file]
+      singular_commands.each do |command|
+        mock_command_classes[command] = Class.new(BaseCommand) do
+          define_method :apply do | root_object, meta: {} |
+            meta[:"dummy_key_for_#{command}"] = :"dummy_value_for_#{command}"
+          end
+        end
+        allow(mock_command_classes[command]).to receive(:new).and_call_original
+        command_class = "#{command.to_s.camelize}Command"
+        stub_const(command_class, mock_command_classes[command])
+      end
+
+      collection_commands = [:build_secondary_claimants, :build_secondary_respondents]
+      collection_commands.each do |command|
+        mock_command_classes[command] = Class.new(BaseCommand) do
+          define_method :initialize do | uuid:, data:, **args |
+            super(uuid: uuid, data: { collection: data }, **args)
+          end
+
+          define_method :apply do | root_object, meta: {} |
+            meta[:"dummy_key_for_#{command}"] = :"dummy_value_for_#{command}"
+          end
+        end
+        allow(mock_command_classes[command]).to receive(:new).and_call_original
+        command_class = "#{command.to_s.camelize}Command"
+        stub_const(command_class, mock_command_classes[command])
+      end
+    end
+  end
+
+  include_context 'with disabled event handlers'
+  include_context 'with mocked sub commands'
+  describe '#apply' do
+    it 'dispatches to BuildClaim' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildClaim" => hash_including(dummy_key_for_build_claim: :dummy_value_for_build_claim)
+    end
+
+    it 'dispatches to BuildPrimaryRespondent' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildPrimaryRespondent" => { dummy_key_for_build_primary_respondent: :dummy_value_for_build_primary_respondent }
+    end
+
+    it 'dispatches to BuildPrimaryClaimant' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildPrimaryClaimant" => { dummy_key_for_build_primary_claimant: :dummy_value_for_build_primary_claimant }
+    end
+
+    it 'dispatches to BuildSecondaryClaimants' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildSecondaryClaimants" => { dummy_key_for_build_secondary_claimants: :dummy_value_for_build_secondary_claimants}
+    end
+
+    it 'dispatches to BuildSecondaryRespondents' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildSecondaryRespondents" => { dummy_key_for_build_secondary_respondents: :dummy_value_for_build_secondary_respondents}
+    end
+
+    it 'dispatches to BuildPrimaryRepresentative' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildPrimaryRepresentative" => { dummy_key_for_build_primary_representative: :dummy_value_for_build_primary_representative }
+    end
+
+    it 'dispatches to BuildPdfFile' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildPdfFile" => { dummy_key_for_build_pdf_file: :dummy_value_for_build_pdf_file }
+    end
+
+    it 'dispatches to BuildClaimantsFile' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildClaimantsFile" => { dummy_key_for_build_claimants_file: :dummy_value_for_build_claimants_file }
+    end
+
+    it 'dispatches to BuildClaimDetailsFile' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildClaimDetailsFile" => { dummy_key_for_build_claim_details_file: :dummy_value_for_build_claim_details_file }
+    end
+
+    it 'dispatches to AssignReferenceToClaim' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildClaim" => hash_including(dummy_key_for_assign_reference_to_claim: :dummy_value_for_assign_reference_to_claim)
+    end
+
+    it 'dispatches to AssignOfficeToClaim' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildClaim" => hash_including(dummy_key_for_assign_office_to_claim: :dummy_value_for_assign_office_to_claim)
+    end
+
+    it 'dispatches to PreAllocatePdfFile' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(example_meta_hash).to include "BuildClaim" => hash_including(dummy_key_for_pre_allocate_pdf_file: :dummy_value_for_pre_allocate_pdf_file)
+    end
+
+    it 'creates the BuildClaim command with the correct data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      input_data = data[:data].detect {|c| c[:command] == 'BuildClaim'}
+      expect(mock_command_classes.build_claim).to have_received(:new).with(async: true, **input_data)
+    end
+
+    it 'creates the BuildPrimaryRespondent command with the correct data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      input_data = data[:data].detect {|c| c[:command] == 'BuildPrimaryRespondent'}
+      expect(mock_command_classes.build_primary_respondent).to have_received(:new).with(async: true, **input_data)
+    end
+
+    it 'creates the BuildPrimaryClaimant command with the correct data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      input_data = data[:data].detect {|c| c[:command] == 'BuildPrimaryClaimant'}
+      expect(mock_command_classes.build_primary_claimant).to have_received(:new).with(async: true, **input_data)
+    end
+
+    it 'creates the BuildSecondaryClaimants command with the correct data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      input_data = data[:data].detect {|c| c[:command] == 'BuildSecondaryClaimants'}
+      expect(mock_command_classes.build_secondary_claimants).to have_received(:new).with(async: true, **input_data)
+    end
+
+    it 'creates the BuildSecondaryRespondents command with the correct data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      input_data = data[:data].detect {|c| c[:command] == 'BuildSecondaryRespondents'}
+      expect(mock_command_classes.build_secondary_respondents).to have_received(:new).with(async: true, **input_data)
+    end
+
+    it 'creates the BuildPrimaryRepresentative command with the correct data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      input_data = data[:data].detect {|c| c[:command] == 'BuildPrimaryRepresentative'}
+      expect(mock_command_classes.build_primary_representative).to have_received(:new).with(async: true, **input_data)
+    end
+
+    it 'creates the BuildPdfFile command with the correct data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      input_data = data[:data].detect {|c| c[:command] == 'BuildPdfFile'}
+      expect(mock_command_classes.build_pdf_file).to have_received(:new).with(async: true, **input_data)
+    end
+
+    it 'creates the BuildClaimantsFile command with the correct data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      input_data = data[:data].detect {|c| c[:command] == 'BuildClaimantsFile'}
+      expect(mock_command_classes.build_claimants_file).to have_received(:new).with(async: true, **input_data)
+    end
+
+    it 'creates the BuildClaimDetailsFile command with the correct data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      input_data = data[:data].detect {|c| c[:command] == 'BuildClaimDetailsFile'}
+      expect(mock_command_classes.build_claim_details_file).to have_received(:new).with(async: true, **input_data)
+    end
+
+    it 'creates the AssignReferenceToClaim command with no data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(mock_command_classes.assign_reference_to_claim).to have_received(:new).with(async: true, uuid: instance_of(String), data: {}, command: 'AssignReferenceToClaim')
+    end
+
+    it 'creates the AssignOfficeToClaim command with no data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(mock_command_classes.assign_office_to_claim).to have_received(:new).with(async: true, uuid: instance_of(String), data: {}, command: 'AssignOfficeToClaim')
+    end
+
+    it 'creates the PreAllocatePdfFile command with no data' do
+      # Act
+      command.apply(root_object, meta: example_meta_hash)
+
+      # Assert
+      expect(mock_command_classes.pre_allocate_pdf_file).to have_received(:new).with(async: true, uuid: instance_of(String), data: {}, command: 'PreAllocatePdfFile')
+    end
+  end
+
+  describe '#valid?' do
+    context 'with all commands valid' do
+
+      it 'contains the correct error key in the pdf_template_reference attributes' do
+        # Act
+        result = command.valid?
+
+        # Assert
+        expect(result).to be true
+      end
+
+    end
+
+    context 'with an error in one of the commands' do
+      before do
+        mock_command_classes.build_primary_claimant.instance_eval do
+          attribute :dummy_attribute, :string
+          validates :dummy_attribute, presence: true
+        end
+      end
+
+      it 'contains the correct error key in the pdf_template_reference attributes' do
+        # Act
+        result = command.valid?
+
+        # Assert
+        expect(result).to be false
+      end
+
+      it 'contains the correct error key in the pdf_template_reference attributes' do
+        # Act
+        command.valid?
+
+        # Assert
+        expect(command.errors[:'data[2].dummy_attribute']).to be_present
+      end
+    end
+  end
+end

--- a/spec/factories/json/json_claim_factory.rb
+++ b/spec/factories/json/json_claim_factory.rb
@@ -28,6 +28,10 @@ FactoryBot.define do
     command { 'SerialSequence' }
     data { [] }
 
+    trait :with_pdf do
+      has_pdf_file { true }
+    end
+
     trait :with_csv do
       case_type { 'Multiple' }
       csv_file_traits { [:simple_user_with_csv_group_claims] }

--- a/spec/requests/v2/create_claim_spec.rb
+++ b/spec/requests/v2/create_claim_spec.rb
@@ -119,6 +119,15 @@ RSpec.describe 'Create Claim Request', type: :request do
         expect(result).to be_an_instance_of Claim
       end
 
+      it 'returns the correct office data structure' do
+        # Assert - make sure the office data is correct
+        office = json_response.dig('meta', 'BuildClaim', 'office').symbolize_keys
+        expect(office).to include code: instance_of(Integer),
+                                  name: instance_of(String),
+                                  telephone: instance_of(String),
+                                  address: instance_of(String)
+      end
+
       it 'returns exactly the same data if called twice with the same uuid', background_jobs: :disable do
         # Arrange - get the response from the first call and reset the session ready for the second
         response1 = JSON.parse(response.body).with_indifferent_access

--- a/spec/requests/v2/create_claim_spec.rb
+++ b/spec/requests/v2/create_claim_spec.rb
@@ -125,7 +125,8 @@ RSpec.describe 'Create Claim Request', type: :request do
         expect(office).to include code: instance_of(Integer),
                                   name: instance_of(String),
                                   telephone: instance_of(String),
-                                  address: instance_of(String)
+                                  address: instance_of(String),
+                                  email: instance_of(String)
       end
 
       it 'returns exactly the same data if called twice with the same uuid', background_jobs: :disable do


### PR DESCRIPTION
Added office data to meta of CreateClaim command RST-1657 API BuildClaim office data

For azure phase 2 - this will allow ET1 to post its data directly from the front end process and not as a background job (it will fail back to a background job though for retrying).  This means that the call to fetch the reference number and office data that is fetched when the user enters the respondent data will no longer be needed.  The reference number and office data are now returned in the metadata of this command for the front end to display