### PR TITLE
Hotfix/log level

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'wisper', '2.0.0'
 gem 'sidekiq', '~> 5.2'
 gem 'sidekiq-cron', '~> 1.1'
 gem 'sidekiq-failures', '~> 1.0'
+gem 'sidekiq_alive', '~> 0.1.0'
 gem 'sentry-raven', '~> 2.7', '>= 2.7.4'
 
 # ET to ATOS File transfer packaged as a rack endpoint (rails engine) for easy deployment as a separate service.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,6 +327,9 @@ GEM
       sidekiq (>= 4.2.1)
     sidekiq-failures (1.0.0)
       sidekiq (>= 4.0.0)
+    sidekiq_alive (0.1.1)
+      sidekiq
+      sinatra
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -412,6 +415,7 @@ DEPENDENCIES
   sidekiq (~> 5.2)
   sidekiq-cron (~> 1.1)
   sidekiq-failures (~> 1.0)
+  sidekiq_alive (~> 0.1.0)
   simplecov (~> 0.16.1)
   site_prism (~> 3.0)
   spring

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'debug').to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -23,3 +23,5 @@ Sidekiq.configure_client do |config|
   redis_config[:password] = ENV['REDIS_PASSWORD'] if ENV['REDIS_PASSWORD'].present?
   config.redis = redis_config
 end
+
+Sidekiq::Logging.logger.level = ::Logger.const_get(ENV.fetch('RAILS_LOG_LEVEL', 'debug').upcase)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,3 +11,4 @@ production:
   - default
   - low
   - mailers
+  - sidekiq_alive


### PR DESCRIPTION
This PR contains changes required for azure infrastructure but will do no harm in AWS either

Here are the changes :-

1. Added sidekiq_alive gem which provides a 'heartbeat' port for sidekiq - allowing it to be monitored by a 'probe' in azure.
2. Log level of application and log level of sidekiq is configurable via environment variable RAILS_LOG_LEVEL (debug, info, warn)